### PR TITLE
Web UI: reclaim operator seat on reconnect — fix right-nav inop after browser refresh (v26.6.2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,6 @@ pat.local
 # Android signing keystores — NEVER commit. Supplied to CI via secrets.
 *.keystore
 *.jks
+
+# Linux deployment bundles — build artifacts produced by deploy/linux/package.sh.
+deploy/linux/*.tar.gz

--- a/Platforms/AgValoniaGPS.Desktop/App.RemoteWiring.cs
+++ b/Platforms/AgValoniaGPS.Desktop/App.RemoteWiring.cs
@@ -453,6 +453,13 @@ public partial class App
                                 case "field.resumeLast": ExecCmd(vm.ResumeLastJobCommand); return;
                                 case "field.driveIn": ExecCmd(vm.DriveInCommand); return;
                                 case "field.close": ExecCmd(vm.CloseFieldCommand); return;
+                                // Unsaved-coverage guard resolution (the web prompt mirrors the
+                                // host's DialogType.UnsavedCoverage). Save creates a job then
+                                // finishes the close; Discard closes dropping coverage; Cancel
+                                // abandons the close. Tier-1 (same as field.close).
+                                case "coverage.saveJob": ExecCmd(vm.SaveCoverageToJobCommand); return;
+                                case "coverage.discardClose": ExecCmd(vm.DiscardCoverageAndCloseCommand); return;
+                                case "coverage.cancelClose": ExecCmd(vm.CancelUnsavedCoverageCommand); return;
                                 // --- AgShare cloud sync (test / fetch / download / upload).
                                 // Replicates the dialog code-behind orchestration host-side;
                                 // results land in ApplicationState.AgShare. Tier-1. ---

--- a/Shared/AgValoniaGPS.RemoteServer/Contracts.cs
+++ b/Shared/AgValoniaGPS.RemoteServer/Contracts.cs
@@ -238,7 +238,12 @@ public record StatusDto(
     // Field Tools → Offset Fix: the current GPS drift offset (meters) the D-pad nudges
     // and the manual inputs edit. Mirrors ApplicationState.Field.Drift{Easting,Northing}.
     double DriftEasting,
-    double DriftNorthing);
+    double DriftNorthing,
+    // Unsaved-coverage guard (server-driven). True while CloseFieldCommand has surfaced the
+    // "coverage painted with no open job" prompt (DialogType.UnsavedCoverage). The web client
+    // renders its own Save/Discard/Cancel prompt off this flag — without it the host opens a
+    // dialog nothing renders and the close hangs. Message text is static (client owns it).
+    bool UnsavedCoveragePrompt);
 
 /// <summary>Config read-frame (Phase 9). A structured projection of
 /// ConfigurationStore for the left-nav settings panels — seeded on connect and

--- a/Shared/AgValoniaGPS.RemoteServer/SceneProjector.cs
+++ b/Shared/AgValoniaGPS.RemoteServer/SceneProjector.cs
@@ -366,7 +366,8 @@ public sealed class SceneProjector
             _persist.State.SimulatorPanelVisible,
             // Field Tools — Offset Fix drift offset (meters).
             _state.Field.DriftEasting,
-            _state.Field.DriftNorthing);
+            _state.Field.DriftNorthing,
+            _state.UI.IsUnsavedCoverageDialogVisible);
     }
 
     // NTRIP profiles read-frame (Network IO). Projects INtripProfileService's saved

--- a/Shared/AgValoniaGPS.RemoteServer/WireCodec.cs
+++ b/Shared/AgValoniaGPS.RemoteServer/WireCodec.cs
@@ -561,6 +561,8 @@ public static class WireCodec
         // Field Tools — Offset Fix drift (meters).
         w.Write((float)s.DriftEasting);
         w.Write((float)s.DriftNorthing);
+        // Unsaved-coverage guard prompt (append-only).
+        w.Write((byte)(s.UnsavedCoveragePrompt ? 1 : 0));
         return ms.ToArray();
     }
 

--- a/Shared/AgValoniaGPS.RemoteServer/wwwroot/app.js
+++ b/Shared/AgValoniaGPS.RemoteServer/wwwroot/app.js
@@ -276,9 +276,9 @@ const transport = RemoteTransport.create({
     if (document.getElementById('boundaryplayer').classList.contains('open')) renderBoundaryPlayer();
   },
   onWizard(w) { wizard = w; wizardDirty = true; },
-  onHello(id) { myClientId = id; updateControlUi(); applyMobileQualityCap(); },
-  onControlState(s) { lastControl = s; updateControlUi(); },
-  onStatus(s) { connState = s; renderRole(); },
+  onHello(id) { myClientId = id; updateControlUi(); claimSeatIfFree(); applyMobileQualityCap(); },
+  onControlState(s) { lastControl = s; updateControlUi(); claimSeatIfFree(); },
+  onStatus(s) { connState = s; renderRole(); claimSeatIfFree(); },
 });
 
 // Mobile auto-quality. Phones/tablets get GPU-overloaded at Ultra resolution (large
@@ -2719,6 +2719,19 @@ function updateControlUi() {
   if (typeof updateAsGated === 'function') updateAsGated(); // re-gate AutoSteer actions
   if (document.getElementById('recpath').classList.contains('open')) renderRecPath(); // re-gate Play
   renderRole();
+}
+// Reclaim the operator seat when it is free. Control is keyed to the WebSocket
+// connection server-side and acquired once, implicitly, at connect. A browser
+// REFRESH opens a new connection while the old one is still registered as holder,
+// so the new connection's implicit acquire is denied; once the stale holder is
+// dropped/deadman-swept the seat goes empty but the new connection never retried —
+// leaving the Tier-2 right-nav menu permanently inop until a server restart. Claiming
+// the empty seat here (driven by the control-state frame the drop/sweep emits, plus
+// connect/hello) makes the operator role survive a refresh. Guarded on !held so it
+// never takes the seat from a live operator — only fills a vacant one (deadman model).
+function claimSeatIfFree() {
+  if (connState === 'connected' && myClientId && !iHoldControl && !lastControl.held)
+    transport.send('control.acquire|Browser');
 }
 // Heartbeat keeps our hold alive while we control; a lapse trips the host deadman
 // (disengage autosteer + sections).

--- a/Shared/AgValoniaGPS.RemoteServer/wwwroot/app.js
+++ b/Shared/AgValoniaGPS.RemoteServer/wwwroot/app.js
@@ -247,21 +247,16 @@ const transport = RemoteTransport.create({
   },
   onCoverageCells(msg) {
     if (!cov || !msg.cells) return;
-    if (cov.surface) {
-      cov.pending.push(msg.cells); // drawn onto the render target in drawCoverageSk (in-frame)
-    } else {
-      const c = msg.cells, H = cov.height, cctx = cov.cctx;
-      let lastRgb = -1;
-      for (let i = 0; i + 2 < c.length; i += 3) {
-        const x = c[i], y = c[i + 1], rgb = c[i + 2];
-        if (rgb !== lastRgb) { cctx.fillStyle = '#' + (rgb >>> 0 & 0xFFFFFF).toString(16).padStart(6, '0'); lastRgb = rgb; }
-        cctx.fillRect(x, H - 1 - y, 1, 1); // flip: high northing at offscreen top
-        covCells++;
-      }
-    }
-    cov.dirty = true;
+    // Queue with arrival time; the actual rasterization is delayed by RENDER_DELAY in
+    // drawCoverageSk (both render paths) so freshly-laid coverage appears on the SAME
+    // playback timeline as the render-delayed tool/pose. Drawing it on arrival put the
+    // real-time coverage front AHEAD of the delayed tool sprite, so coverage poked out in
+    // front of the tool at speed (gap = speed × RENDER_DELAY; hidden under the tool below
+    // ~5 km/h, visible above). arrival + RENDER_DELAY matches the host-timeline pose
+    // playback exactly (same socket/latency), so the front now tracks the tool at any speed.
+    cov.pending.push({ cells: msg.cells, t: performance.now() });
   },
-  onStatusBar(s) { statusBar = s; if (typeof applySimBarVisible === 'function') applySimBarVisible(); },
+  onStatusBar(s) { statusBar = s; if (typeof applySimBarVisible === 'function') applySimBarVisible(); syncUnsavedCov(); },
   onConfig(c) { config = c; configDirty = true; },
   onProfiles(p) { profiles = p; profilesDirty = true; },
   onNtripProfiles(p) { ntripProfiles = p; ntripDirty = true; },
@@ -572,7 +567,13 @@ function showConfirm(title, message, onConfirm) {
   document.getElementById('dlgc-msg').textContent = message || '';
   openDialog('dlg-confirm');
 }
-dialogHost.querySelector('.dlg-backdrop').addEventListener('pointerdown', e => { e.stopPropagation(); closeDialog(); });
+dialogHost.querySelector('.dlg-backdrop').addEventListener('pointerdown', e => {
+  e.stopPropagation();
+  // Backdrop-dismiss of the unsaved-coverage guard must resolve it (= Cancel), else the
+  // host stays blocked with its dialog open and the field never closes.
+  if (_ucovOpen) { _ucovOpen = false; transport.send('coverage.cancelClose'); }
+  closeDialog();
+});
 dialogHost.addEventListener('pointerdown', e => e.stopPropagation()); // keep map from panning
 const dlgLat = document.getElementById('dlg-lat'), dlgLon = document.getElementById('dlg-lon');
 function openSimCoords() {
@@ -596,6 +597,27 @@ document.getElementById('dlgc-ok').addEventListener('pointerdown', e => {
   e.preventDefault(); e.stopPropagation();
   const cb = _confirmCb; closeDialog(); if (cb) cb();
 });
+
+// ---- unsaved-coverage guard (server-driven) ----
+// CloseFieldCommand opens DialogType.UnsavedCoverage on the host when coverage was painted
+// with no open job. The host has no UI, so we render the prompt here off the Status flag and
+// resolve it with the matching host commands (SaveCoverageToJob / DiscardCoverageAndClose /
+// CancelUnsavedCoverage). Without this the host opens a dialog nothing shows and the close hangs.
+let _ucovOpen = false;
+function syncUnsavedCov() {
+  const want = !!(statusBar && statusBar.unsavedCoveragePrompt);
+  if (want && !_ucovOpen) { _ucovOpen = true; openDialog('dlg-unsavedcov'); }
+  else if (!want && _ucovOpen) {
+    _ucovOpen = false;
+    if (document.getElementById('dlg-unsavedcov').classList.contains('open')) closeDialog();
+  }
+}
+// Resolve optimistically (close now); the host command also flips the Status flag false, so
+// the next frame is a no-op rather than a re-open.
+function ucovResolve(cmd) { _ucovOpen = false; transport.send(cmd); closeDialog(); }
+document.getElementById('ucov-save').addEventListener('pointerdown', e => { e.preventDefault(); e.stopPropagation(); ucovResolve('coverage.saveJob'); });
+document.getElementById('ucov-discard').addEventListener('pointerdown', e => { e.preventDefault(); e.stopPropagation(); ucovResolve('coverage.discardClose'); });
+document.getElementById('ucov-cancel').addEventListener('pointerdown', e => { e.preventDefault(); e.stopPropagation(); ucovResolve('coverage.cancelClose'); });
 
 // ---- section bar (Phase 7) — per-section colour strip + manual toggle ----
 // Read state (per-section ColorCode + master/manual mode) already rides the Tick;
@@ -4337,21 +4359,28 @@ function drawSatelliteSk(canvas) {
 const COV_REBUILD_MS = 250;
 function drawCoverageSk(canvas) {
   if (!cov) return;
+  // Only rasterize batches that have aged past RENDER_DELAY, so coverage lands on the same
+  // playback timeline as the render-delayed tool (see onCoverageCells). pending is FIFO in
+  // arrival time, so the first not-yet-aged batch ends the drain.
+  const cutoff = performance.now() - RENDER_DELAY;
   if (cov.surface) {
-    // GPU render target: draw only the pending NEW cells onto it, then snapshot (a GPU
+    // GPU render target: draw only the aged pending NEW cells onto it, then snapshot (a GPU
     // texture COW — cheap). No whole-texture upload, so no regular per-rebuild stutter.
-    if (cov.pending.length) {
+    if (cov.pending.length && cov.pending[0].t <= cutoff) {
       const sk = cov.surface.getCanvas(), paint = cov.covPaint, H = cov.height;
-      let lastRgb = -1;
-      for (const c of cov.pending) {
+      let lastRgb = -1, drained = 0;
+      for (const batch of cov.pending) {
+        if (batch.t > cutoff) break;
+        const c = batch.cells;
         for (let i = 0; i + 2 < c.length; i += 3) {
           const x = c[i], y = c[i + 1], rgb = c[i + 2] >>> 0 & 0xFFFFFF;
           if (rgb !== lastRgb) { paint.setColor(CK.Color((rgb >> 16) & 0xFF, (rgb >> 8) & 0xFF, rgb & 0xFF, 1)); lastRgb = rgb; }
           sk.drawRect(CK.XYWHRect(x, H - 1 - y, 1, 1), paint); // flip: high northing at top
           covCells++;
         }
+        drained++;
       }
-      cov.pending.length = 0;
+      cov.pending.splice(0, drained);
       cov.surface.flush();
       cov.dirty = true;
     }
@@ -4362,6 +4391,24 @@ function drawCoverageSk(canvas) {
     }
   } else {
     const nowMs = performance.now();
+    // 2D fallback: drain aged batches into the offscreen canvas (same RENDER_DELAY gate).
+    if (cov.pending.length && cov.pending[0].t <= cutoff) {
+      const H = cov.height, cctx = cov.cctx;
+      let lastRgb = -1, drained = 0;
+      for (const batch of cov.pending) {
+        if (batch.t > cutoff) break;
+        const c = batch.cells;
+        for (let i = 0; i + 2 < c.length; i += 3) {
+          const x = c[i], y = c[i + 1], rgb = c[i + 2];
+          if (rgb !== lastRgb) { cctx.fillStyle = '#' + (rgb >>> 0 & 0xFFFFFF).toString(16).padStart(6, '0'); lastRgb = rgb; }
+          cctx.fillRect(x, H - 1 - y, 1, 1); // flip: high northing at offscreen top
+          covCells++;
+        }
+        drained++;
+      }
+      cov.pending.splice(0, drained);
+      cov.dirty = true;
+    }
     if (!cov.skImg || (cov.dirty && nowMs - (cov.lastBuild || 0) >= COV_REBUILD_MS)) {
       if (cov.skImg) cov.skImg.delete();
       cov.skImg = CK.MakeImageFromCanvasImageSource(cov.canvas);

--- a/Shared/AgValoniaGPS.RemoteServer/wwwroot/index.html
+++ b/Shared/AgValoniaGPS.RemoteServer/wwwroot/index.html
@@ -2359,6 +2359,17 @@
         <button id="dlgc-ok" class="dlg-btn dlg-ok">Confirm</button>
       </div>
     </div>
+    <!-- Unsaved-coverage guard (server-driven via Status.unsavedCoveragePrompt): coverage
+         painted with no open job. Three outcomes — Save to a job, Discard, or Cancel the close. -->
+    <div id="dlg-unsavedcov" class="dlg-card">
+      <div class="dlg-title">Unsaved Coverage</div>
+      <div class="dlg-msg">You've worked this field without an open job, so the coverage won't be saved. Save it to a job, or it will be lost.</div>
+      <div class="dlg-buttons">
+        <button id="ucov-cancel" class="dlg-btn dlg-cancel">Cancel</button>
+        <button id="ucov-discard" class="dlg-btn dlg-cancel">Discard</button>
+        <button id="ucov-save" class="dlg-btn dlg-ok">Save to Job</button>
+      </div>
+    </div>
     <!-- Quick AB Line creator (mirrors native QuickABSelectorPanel) — GPS-driven modes. -->
     <div id="dlg-quickab" class="dlg-card">
       <div class="dlg-title">Quick AB Line</div>

--- a/Shared/AgValoniaGPS.RemoteServer/wwwroot/transport.js
+++ b/Shared/AgValoniaGPS.RemoteServer/wwwroot/transport.js
@@ -132,6 +132,7 @@ window.RemoteTransport = {
           const ntripConnected = !!u8(), ntripStatus = str(), ntripBytes = f64(), ntripTestStatus = str();
           const simPanelVisible = !!u8();
           const driftEasting = f32(), driftNorthing = f32();
+          const unsavedCoveragePrompt = !!u8();
           handlers.onStatusBar && handlers.onStatusBar({
             fixQuality, fixText, age, sats, isMetric,
             gpsOk, imuOk, autoSteerOk, machineOk, imuIp, autoSteerIp, machineIp,
@@ -141,7 +142,7 @@ window.RemoteTransport = {
             actualSteerAngle, sensorPercent, setSteerAngle, freeDriveAngle, steerFreeDrive,
             swCollecting, swSamples, swMean, swMedian, swStdDev, swOffsetDeg, swConfidence, swValid,
             gpsIp, moduleSubnet, hostIps, ntripConnected, ntripStatus, ntripBytes, ntripTestStatus,
-            simPanelVisible, driftEasting, driftNorthing,
+            simPanelVisible, driftEasting, driftNorthing, unsavedCoveragePrompt,
           });
           break;
         }

--- a/sys/version.h
+++ b/sys/version.h
@@ -5,7 +5,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 6
-#define VERSION_PATCH 1
+#define VERSION_PATCH 2
 
-#define VERSION "26.6.1"
-#define VERSION_DATE "2026-06-20"
+#define VERSION "26.6.2"
+#define VERSION_DATE "2026-06-21"

--- a/sys/version.h
+++ b/sys/version.h
@@ -5,7 +5,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 6
-#define VERSION_PATCH 2
+#define VERSION_PATCH 4
 
-#define VERSION "26.6.2"
+#define VERSION "26.6.4"
 #define VERSION_DATE "2026-06-21"


### PR DESCRIPTION
## Problem
On a browser **refresh**, the remote UI reconnects and the operator keeps driving, but the entire **right-nav actuation menu is inoperable** (left menu + simulator still work). Only a **server restart** restores it. Reported and reproduced on the x86 mini-PC.

## Root cause
Remote control authority is keyed to the **WebSocket connection** and acquired **once**, implicitly, server-side at connect (`WebSocketHub.HandleAsync` → `ControlAuthority.Acquire`). On refresh the new connection opens before the server detects the old socket closed, so the new connection's implicit acquire is **denied** (old connection still registered as holder). The old connection then drops / deadman-sweeps and the seat goes **empty**, but the new connection **never retries** — so it permanently lacks fresh authority and the hub silently drops every Tier-2 command (`restricted(id) && !HoldsFresh(conn) → return`). Tier-1 commands aren't authority-gated, so the left menu/simulator stayed live.

## Fix
The client now **reclaims the empty operator seat** (`claimSeatIfFree`) whenever it's connected, doesn't hold control, and the seat isn't held — driven by the control-state frame the drop/sweep emits, plus connect/hello. The `!held` guard means it only fills a **vacant** seat, never takes one from a live operator, so the single-operator/deadman safety model is preserved. Recovery is automatic within the ~1.5 s deadman window; the brief failsafe disengage during the reconnect gap is intentional (operator screen gone → actuation drops until a live operator returns).

## Verification
Built and deployed to the x86 mini-PC; refreshing the browser mid-session now returns to **Operator** with the right-nav menu live again, no server restart. Confirmed working on hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)