### PR TITLE
deploy/linux: install ICU (libicu) — hard .NET globalization dependency

### DIFF
--- a/deploy/linux/README.md
+++ b/deploy/linux/README.md
@@ -65,6 +65,12 @@ point `AGOPENWEB_DATA` at it.
 
 ## Notes
 
+- **ICU (libicu) is required.** .NET's globalization needs it and it is NOT bundled in
+  the self-contained publish, nor shipped by default on minimal images (Armbian / Debian
+  Trixie, etc.). Without it the host won't start at all (`System.Globalization` throws on
+  load). `install.sh` apt-installs the right `libicuNN` (resolved per Debian release, e.g.
+  `libicu76` on Trixie), falling back to `libicu-dev`. On a non-apt distro install libicu
+  manually (or `libicu-dev` / `icu-devtools` both pull it in).
 - The build is **not trimmed** — the steer wizard projects step ViewModels by
   reflection, which trimming would break. Self-contained-untrimmed is ~160 MB
   (bundles the .NET runtime; the unused Avalonia desktop natives ride along but are

--- a/deploy/linux/install.sh
+++ b/deploy/linux/install.sh
@@ -99,6 +99,25 @@ fi
 # Best-effort device groups (may not exist on every distro).
 for g in dialout can; do getent group "$g" >/dev/null && usermod -aG "$g" "$SVC_USER" || true; done
 
+# ICU — .NET's globalization library. HARD requirement: without libicu the host won't
+# start at all (System.Globalization throws on load, before anything runs). It is NOT part
+# of the self-contained .NET bundle, and minimal images (Armbian / Debian Trixie, etc.) do
+# not ship it by default. The runtime package is version-stamped (libicu76 on Trixie,
+# libicu72 on Bookworm, …), so resolve the concrete name from apt rather than hardcoding;
+# fall back to libicu-dev (version-agnostic — it depends on the current libicuNN).
+if command -v apt-get >/dev/null 2>&1; then
+  # || true: under `set -euo pipefail` a non-zero apt-cache (empty cache / no match) must
+  # not abort the install — an empty result just falls through to the libicu-dev fallback.
+  ICU_PKG="$(apt-cache search --names-only '^libicu[0-9][0-9]*$' 2>/dev/null | sort -V | tail -n1 | cut -d' ' -f1 || true)"
+  [[ -z "$ICU_PKG" ]] && ICU_PKG="libicu-dev"
+  echo "==> Ensuring .NET ICU dependency ($ICU_PKG)…"
+  apt-get install -y --no-install-recommends "$ICU_PKG" \
+    || { echo "   ERROR: failed to install ICU ($ICU_PKG) — the host will NOT start without it."; \
+         echo "          Install it manually, e.g.: sudo apt-get install libicu-dev"; }
+else
+  echo "==> NOTE: .NET requires ICU (libicu). Install it via your package manager or the host won't start."
+fi
+
 # SkiaSharp native deps. The host composites boundary imagery with SkiaSharp, whose
 # bundled libSkiaSharp.so dynamically links libfontconfig + libGL. They are NOT part
 # of the self-contained .NET bundle, so a minimal board (e.g. the Uno Q) lacks


### PR DESCRIPTION
## Problem
On a minimal image (Armbian / Debian Trixie), the freshly-installed host **fails to start** — `System.Globalization` throws on load because **ICU (libicu) is missing**. .NET needs ICU for globalization, it isn't bundled in the self-contained publish, and minimal images don't ship it by default. Observed on the Uno Q's Armbian; likely affects other minimal distros.

## Fix
`install.sh` now installs ICU before launching. The runtime package is version-stamped per Debian release (`libicu76` on Trixie, `libicu72` on Bookworm, …), so the script resolves the concrete name from apt and falls back to `libicu-dev` (version-agnostic — what `icu-devtools` / `libicu-dev` both pull in). The resolve pipeline is guarded with `|| true` so an empty apt cache can't abort the install under `set -euo pipefail`. README documents the requirement and the manual fallback.

## Verification
Reported and worked around on Armbian by installing `icu-devtools`; this automates the equivalent during install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)