### PR TITLE
Windows: in-process launcher app (start/stop backend + open browser) (v26.6.5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,5 +89,6 @@ pat.local
 *.keystore
 *.jks
 
-# Linux deployment bundles — build artifacts produced by deploy/linux/package.sh.
+# Deployment bundles — build artifacts produced by deploy/*/package.sh.
 deploy/linux/*.tar.gz
+deploy/windows/*.zip

--- a/Platforms/AgValoniaGPS.Desktop/BackendHost.cs
+++ b/Platforms/AgValoniaGPS.Desktop/BackendHost.cs
@@ -1,0 +1,161 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2026 AgValoniaGPS Contributors
+//
+// Licensed under GNU GPL v3. See LICENSE.md.
+
+using System;
+using System.Threading.Tasks;
+using AgValoniaGPS.Desktop.DependencyInjection;
+using AgValoniaGPS.Models.Configuration;
+using AgValoniaGPS.Models.State;
+using AgValoniaGPS.Services;
+using AgValoniaGPS.Services.Interfaces;
+using AgValoniaGPS.Services.Threading;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace AgValoniaGPS.Desktop;
+
+/// <summary>
+/// The display-less guidance backend — DI + control loops + the embedded browser server —
+/// factored out of <see cref="HeadlessHost"/> so BOTH the systemd/console daemon
+/// (HeadlessHost) and the in-process Windows launcher (<see cref="Launcher.LauncherWindow"/>)
+/// drive the same lifecycle. There is exactly one of these alive at a time.
+///
+/// Reproduces the non-UI half of <see cref="App.OnFrameworkInitializationCompleted"/>: build
+/// DI (UI-thread role played by a single <see cref="HostLoopDispatcher"/>), load
+/// settings/config/state, construct the single <c>MainViewModel</c> (which starts the 100 Hz
+/// control loop + render-pull/status timers on the host loop), start the RemoteServer, and
+/// wire its command handler + projectors to the VM via <see cref="App.WireRemoteServer"/>.
+///
+/// The daemon awaits <see cref="WaitForShutdownAsync"/> (SIGTERM/Ctrl-C via the generic host
+/// lifetime); the launcher calls <see cref="StopAsync"/> from a button. Both routes fire the
+/// ApplicationStopping save (config + state) BEFORE the provider is disposed.
+/// </summary>
+internal sealed class BackendHost
+{
+    private HostLoopDispatcher? _hostLoop;
+    private IHost? _host;
+    private AgValoniaGPS.RemoteServer.RemoteServerHost? _remoteServer;
+
+    /// <summary>True once <see cref="StartAsync"/> has completed and before <see cref="StopAsync"/>.</summary>
+    public bool IsRunning { get; private set; }
+
+    /// <summary>The embedded server (status readouts: <c>Port</c>, <c>ClientCount</c>). Null until started.</summary>
+    public AgValoniaGPS.RemoteServer.RemoteServerHost? Server => _remoteServer;
+
+    /// <summary>Build DI, load persisted state, construct the VM, start + wire the RemoteServer,
+    /// then start the generic host. Returns once the backend is live and serving.</summary>
+    public async Task StartAsync(string[] args)
+    {
+        if (IsRunning) return;
+
+        // The single host-loop thread that stands in for the Avalonia UI thread.
+        var hostLoop = new HostLoopDispatcher();
+
+        var host = Host.CreateDefaultBuilder(args)
+            // Under a systemd Type=notify service: SystemdLifetime (SIGTERM + READY=1) +
+            // journald log format. No-op off systemd (so the console daemon keeps
+            // ConsoleLifetime, and the Windows launcher just gets the default lifetime,
+            // which it never waits on — it drives stop from a button).
+            .UseSystemd()
+            .ConfigureServices(services =>
+            {
+                services.AddAgValoniaServices();
+
+                // Headless overrides (last registration wins). The Avalonia-backed
+                // dispatcher/timer and SkiaMapControl MapService from AddAgValoniaServices
+                // are never resolved on this path.
+                services.AddSingleton(hostLoop);
+                services.AddSingleton<IUiDispatcher>(hostLoop);
+                services.AddSingleton<IUiTimerFactory>(hostLoop);
+                services.AddSingleton<IMapService, NullMapService>();
+
+                // Pets the systemd hardware watchdog (WatchdogSec) via sd_notify; no-op
+                // when not under a watchdog-enabled systemd service.
+                services.AddHostedService<SystemdWatchdogService>();
+            })
+            .Build();
+
+        App.Services = host.Services;
+        var sp = host.Services;
+        sp.WireUpServices();
+
+        // Load persisted settings → ConfigurationStore, then persistent app state.
+        var settingsService = sp.GetRequiredService<ISettingsService>();
+        settingsService.Load();
+        var configService = sp.GetRequiredService<IConfigurationService>();
+        configService.LoadAppSettings();
+        var persistentState = sp.GetRequiredService<IPersistentStateService>();
+        persistentState.Load();
+
+        // Construct the single MainViewModel from DI (starts the control loop + the
+        // render-pull / status timers, which fire on the host loop).
+        var vm = sp.GetRequiredService<AgValoniaGPS.ViewModels.MainViewModel>();
+
+        // Start the embedded browser server, then wire its command handler + projectors.
+        var remoteServer = new AgValoniaGPS.RemoteServer.RemoteServerHost();
+        await remoteServer.StartAsync(
+            sp.GetRequiredService<ApplicationState>(),
+            sp.GetRequiredService<ICoverageMapService>(),
+            sp.GetRequiredService<ISectionControlService>(),
+            sp.GetRequiredService<IToolPositionService>(),
+            sp.GetRequiredService<ConfigurationStore>(),
+            sp.GetRequiredService<IJobService>(),
+            sp.GetRequiredService<IConfigurationService>(),
+            sp.GetRequiredService<IAutoSteerService>(),
+            sp.GetRequiredService<ISmartWasCalibrationService>(),
+            sp.GetRequiredService<IUdpCommunicationService>(),
+            sp.GetRequiredService<INtripProfileService>(),
+            sp.GetRequiredService<AgValoniaGPS.Services.IFieldService>(),
+            sp.GetRequiredService<ISettingsService>(),
+            sp.GetRequiredService<IVehicleProfileService>(),
+            sp.GetRequiredService<IPersistentStateService>());
+
+        // Wire on the host loop so the command handler runs serialized with the render-pull /
+        // status timers, exactly as the Avalonia UI thread does in the windowed build.
+        hostLoop.Post(() => App.WireRemoteServer(remoteServer, vm, sp, configService));
+
+        // Persist config + state and stop the embedded server during ApplicationStopping,
+        // which fires WHILE the provider is still alive (a save after the provider is
+        // disposed throws). Registered first so it completes before the host tears down.
+        // Uses captured locals only.
+        var lifetime = sp.GetRequiredService<IHostApplicationLifetime>();
+        lifetime.ApplicationStopping.Register(() =>
+        {
+            Console.WriteLine("[backend] shutting down — saving config + state…");
+            try { configService.SaveAppSettings(); } catch (Exception ex) { Console.WriteLine($"[backend] save config failed: {ex.Message}"); }
+            try { persistentState.Save(); } catch (Exception ex) { Console.WriteLine($"[backend] save state failed: {ex.Message}"); }
+            try { remoteServer.StopAsync().GetAwaiter().GetResult(); } catch (Exception ex) { Console.WriteLine($"[backend] server stop failed: {ex.Message}"); }
+            Console.WriteLine("[backend] stopped.");
+        });
+
+        await host.StartAsync();
+
+        _hostLoop = hostLoop;
+        _host = host;
+        _remoteServer = remoteServer;
+        IsRunning = true;
+    }
+
+    /// <summary>Blocks until the generic host lifetime signals shutdown (SIGTERM / Ctrl-C /
+    /// systemd stop). Used by the console/systemd daemon; the launcher never calls this.</summary>
+    public Task WaitForShutdownAsync() =>
+        _host?.WaitForShutdownAsync() ?? Task.CompletedTask;
+
+    /// <summary>Stop the host (fires ApplicationStopping → save) and release everything.
+    /// Idempotent. After this the backend can be started again with a fresh instance.</summary>
+    public async Task StopAsync()
+    {
+        if (_host is { } host)
+        {
+            try { await host.StopAsync(); } catch { /* a stop fault must not wedge the caller */ }
+            host.Dispose();
+        }
+        _hostLoop?.Dispose();
+        _host = null;
+        _hostLoop = null;
+        _remoteServer = null;
+        IsRunning = false;
+    }
+}

--- a/Platforms/AgValoniaGPS.Desktop/HeadlessHost.cs
+++ b/Platforms/AgValoniaGPS.Desktop/HeadlessHost.cs
@@ -8,14 +8,6 @@
 
 using System;
 using System.Threading.Tasks;
-using AgValoniaGPS.Desktop.DependencyInjection;
-using AgValoniaGPS.Models.Configuration;
-using AgValoniaGPS.Models.State;
-using AgValoniaGPS.Services;
-using AgValoniaGPS.Services.Interfaces;
-using AgValoniaGPS.Services.Threading;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 
 namespace AgValoniaGPS.Desktop;
 
@@ -43,99 +35,14 @@ internal static class HeadlessHost
     {
         Console.WriteLine("[headless] AgOpenWeb host starting (no window; browser is the UI)…");
 
-        // The single host-loop thread that stands in for the Avalonia UI thread.
-        var hostLoop = new HostLoopDispatcher();
-
-        var host = Host.CreateDefaultBuilder(args)
-            // When launched as a systemd Type=notify service: swap in SystemdLifetime
-            // (handles SIGTERM + sends READY=1 once started), and format logs for
-            // journald. A no-op when not run under systemd, so dotnet run still uses
-            // ConsoleLifetime (Ctrl-C). See Plans/DEPLOYMENT_PATTERNS.md.
-            .UseSystemd()
-            .ConfigureServices(services =>
-            {
-                services.AddAgValoniaServices();
-
-                // Headless overrides (last registration wins on resolve). The
-                // Avalonia-backed dispatcher/timer and the SkiaMapControl-backed
-                // MapService registered by AddAgValoniaServices are never resolved.
-                services.AddSingleton(hostLoop);
-                services.AddSingleton<IUiDispatcher>(hostLoop);
-                services.AddSingleton<IUiTimerFactory>(hostLoop);
-                services.AddSingleton<IMapService, NullMapService>();
-
-                // Pets the systemd hardware watchdog (WatchdogSec) via sd_notify;
-                // no-op when not under a watchdog-enabled systemd service.
-                services.AddHostedService<SystemdWatchdogService>();
-            })
-            .Build();
-
-        App.Services = host.Services;
-        var services2 = host.Services;
-        services2.WireUpServices();
-
-        // Load persisted settings → ConfigurationStore, then persistent app state.
-        // (Mirrors App.OnFrameworkInitializationCompleted; no sound extraction /
-        // font / language-to-Avalonia steps — those are UI-only.)
-        var settingsService = services2.GetRequiredService<ISettingsService>();
-        settingsService.Load();
-        var configService = services2.GetRequiredService<IConfigurationService>();
-        configService.LoadAppSettings();
-        // Resolve into a local now so the shutdown save below never calls
-        // GetRequiredService on a torn-down provider.
-        var persistentState = services2.GetRequiredService<IPersistentStateService>();
-        persistentState.Load();
-
-        // Construct the single MainViewModel from DI. This starts the control loop
-        // and the render-pull / status timers (the timers fire on the host loop).
-        var vm = services2.GetRequiredService<AgValoniaGPS.ViewModels.MainViewModel>();
-
-        // Start the embedded browser server, then wire its command handler +
-        // projectors to the live VM (shared with the windowed path).
-        var remoteServer = new AgValoniaGPS.RemoteServer.RemoteServerHost();
-        await remoteServer.StartAsync(
-            services2.GetRequiredService<ApplicationState>(),
-            services2.GetRequiredService<ICoverageMapService>(),
-            services2.GetRequiredService<ISectionControlService>(),
-            services2.GetRequiredService<IToolPositionService>(),
-            services2.GetRequiredService<ConfigurationStore>(),
-            services2.GetRequiredService<IJobService>(),
-            services2.GetRequiredService<IConfigurationService>(),
-            services2.GetRequiredService<IAutoSteerService>(),
-            services2.GetRequiredService<ISmartWasCalibrationService>(),
-            services2.GetRequiredService<IUdpCommunicationService>(),
-            services2.GetRequiredService<INtripProfileService>(),
-            services2.GetRequiredService<AgValoniaGPS.Services.IFieldService>(),
-            services2.GetRequiredService<ISettingsService>(),
-            services2.GetRequiredService<IVehicleProfileService>(),
-            services2.GetRequiredService<IPersistentStateService>());
-
-        // Wire on the host loop so the command handler runs serialized with the
-        // render-pull / status timers, exactly like the Avalonia UI thread does.
-        hostLoop.Post(() => App.WireRemoteServer(remoteServer, vm, services2, configService));
+        var backend = new BackendHost();
+        await backend.StartAsync(args);
 
         Console.WriteLine("[headless] ready — browse to http://localhost:5174 (or the LAN IP).");
 
-        // Persist config + state and stop the embedded server during the host's
-        // ApplicationStopping phase, which fires WHILE the service provider is still
-        // alive. host.RunAsync() disposes the provider in its finally, so doing this
-        // AFTER RunAsync returns would hit a disposed IServiceProvider (the state save
-        // failed that way). ApplicationStopping callbacks run synchronously when a
-        // signal triggers StopApplication, before any disposal; this one is registered
-        // first, so it completes before the host tears down. Uses captured locals only.
-        var lifetime = host.Services.GetRequiredService<IHostApplicationLifetime>();
-        lifetime.ApplicationStopping.Register(() =>
-        {
-            Console.WriteLine("[headless] shutting down — saving config + state…");
-            try { configService.SaveAppSettings(); } catch (Exception ex) { Console.WriteLine($"[headless] save config failed: {ex.Message}"); }
-            try { persistentState.Save(); } catch (Exception ex) { Console.WriteLine($"[headless] save state failed: {ex.Message}"); }
-            try { remoteServer.StopAsync().GetAwaiter().GetResult(); } catch (Exception ex) { Console.WriteLine($"[headless] server stop failed: {ex.Message}"); }
-            Console.WriteLine("[headless] stopped.");
-        });
-
-        // Block until SIGINT (Ctrl-C) / SIGTERM (systemd stop) / SIGQUIT, handled by
-        // the generic host's ConsoleLifetime — Microsoft's tested cross-platform impl.
-        await host.RunAsync();
-        hostLoop.Dispose();
+        // Block until SIGINT (Ctrl-C) / SIGTERM (systemd stop) / SIGQUIT via the generic
+        // host lifetime, then stop (fires the ApplicationStopping save before disposal).
+        await backend.WaitForShutdownAsync();
+        await backend.StopAsync();
     }
 }

--- a/Platforms/AgValoniaGPS.Desktop/Launcher/LauncherApplication.cs
+++ b/Platforms/AgValoniaGPS.Desktop/Launcher/LauncherApplication.cs
@@ -1,0 +1,31 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2026 AgValoniaGPS Contributors
+//
+// Licensed under GNU GPL v3. See LICENSE.md.
+
+using Avalonia;
+using Avalonia.Controls; // ShutdownMode
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Themes.Fluent;
+
+namespace AgValoniaGPS.Desktop.Launcher;
+
+/// <summary>
+/// A minimal Avalonia <see cref="Application"/> for the launcher — NOT the full guidance
+/// <see cref="App"/> (no map window, no MainViewModel-as-UI). Just a Fluent theme and the
+/// tiny <see cref="LauncherWindow"/>; the backend it controls runs headless in-process.
+/// </summary>
+public sealed class LauncherApplication : Application
+{
+    public override void Initialize() => Styles.Add(new FluentTheme());
+
+    public override void OnFrameworkInitializationCompleted()
+    {
+        if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
+        {
+            desktop.MainWindow = new LauncherWindow(LauncherEntry.Args);
+            desktop.ShutdownMode = ShutdownMode.OnMainWindowClose;
+        }
+        base.OnFrameworkInitializationCompleted();
+    }
+}

--- a/Platforms/AgValoniaGPS.Desktop/Launcher/LauncherEntry.cs
+++ b/Platforms/AgValoniaGPS.Desktop/Launcher/LauncherEntry.cs
@@ -1,0 +1,32 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2026 AgValoniaGPS Contributors
+//
+// Licensed under GNU GPL v3. See LICENSE.md.
+
+using System;
+using Avalonia;
+
+namespace AgValoniaGPS.Desktop.Launcher;
+
+/// <summary>
+/// Entry for the in-process launcher mode (Windows default; <c>--launcher</c> on any OS).
+/// Boots a minimal Avalonia desktop app (<see cref="LauncherApplication"/>) whose only window
+/// supervises the headless <see cref="BackendHost"/>. Distinct from <see cref="HeadlessHost"/>
+/// (display-less daemon) and the full windowed <see cref="App"/> (legacy native UI).
+/// </summary>
+internal static class LauncherEntry
+{
+    /// <summary>The process args, exposed to <see cref="LauncherApplication"/> so the window
+    /// passes them through to <see cref="BackendHost.StartAsync"/> (host config binding).</summary>
+    public static string[] Args { get; private set; } = Array.Empty<string>();
+
+    public static void Run(string[] args)
+    {
+        Args = args;
+        AppBuilder.Configure<LauncherApplication>()
+            .UsePlatformDetect()
+            .WithInterFont()
+            .LogToTrace()
+            .StartWithClassicDesktopLifetime(args);
+    }
+}

--- a/Platforms/AgValoniaGPS.Desktop/Launcher/LauncherWindow.cs
+++ b/Platforms/AgValoniaGPS.Desktop/Launcher/LauncherWindow.cs
@@ -1,0 +1,277 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2026 AgValoniaGPS Contributors
+//
+// Licensed under GNU GPL v3. See LICENSE.md.
+
+using System;
+using System.Diagnostics;
+using System.Net;
+using System.Net.NetworkInformation;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Shapes;
+using Avalonia.Input.Platform; // ClipboardExtensions.SetTextAsync
+using Avalonia.Layout;
+using Avalonia.Media;
+using Avalonia.Platform;
+using Avalonia.Styling;
+using Avalonia.Threading;
+
+namespace AgValoniaGPS.Desktop.Launcher;
+
+/// <summary>
+/// The in-process Windows launcher — a small app-like window that starts/stops the headless
+/// guidance backend (<see cref="BackendHost"/>) and opens the web UI in the default browser.
+/// The backend runs IN THIS PROCESS on its own host-loop thread; this window is just the
+/// supervisor/console for the Windows-centric AgOpen audience, who expect a program with
+/// buttons, not a systemd daemon. Naturally cross-platform (Avalonia), but Windows is the
+/// reason it exists; Linux/macOS use the systemd unit instead.
+/// </summary>
+internal sealed class LauncherWindow : Window
+{
+    private readonly string[] _args;
+    private BackendHost? _backend;
+    private bool _busy;
+    private bool _closing;
+
+    // Controls updated by UpdateUi().
+    private readonly Ellipse _dot = new() { Width = 12, Height = 12, Margin = new Thickness(0, 0, 8, 0) };
+    private readonly TextBlock _statusText = new() { VerticalAlignment = VerticalAlignment.Center, FontSize = 15, FontWeight = FontWeight.SemiBold };
+    private readonly TextBlock _urlText = new() { VerticalAlignment = VerticalAlignment.Center, FontFamily = new FontFamily("Consolas, Menlo, monospace") };
+    private readonly TextBlock _clientsText = new() { Foreground = new SolidColorBrush(Color.Parse("#9fb3cc")), FontSize = 12 };
+    private readonly Button _startStop = new() { HorizontalAlignment = HorizontalAlignment.Stretch, HorizontalContentAlignment = HorizontalAlignment.Center, Height = 38 };
+    private readonly Button _open = new() { Content = "Open in Browser", HorizontalAlignment = HorizontalAlignment.Stretch, HorizontalContentAlignment = HorizontalAlignment.Center, Height = 38 };
+    private readonly Button _copy = new() { Content = "Copy", Padding = new Thickness(10, 4), MinWidth = 0 };
+    private readonly CheckBox _autoOpen = new() { Content = "Open browser when started", IsChecked = true };
+    private readonly CheckBox _runOnLogin = new() { Content = "Start with Windows" };
+
+    public LauncherWindow(string[] args)
+    {
+        _args = args;
+
+        Title = "AgOpenWeb";
+        Width = 400;
+        SizeToContent = SizeToContent.Height;
+        CanResize = false;
+        WindowStartupLocation = WindowStartupLocation.CenterScreen;
+        RequestedThemeVariant = ThemeVariant.Dark;
+        TryLoadIcon();
+
+        _urlText.Text = LanUrl();
+        _runOnLogin.IsVisible = OperatingSystem.IsWindows();
+        _runOnLogin.IsChecked = RunOnLoginEnabled();
+
+        _startStop.Click += (_, _) => { if (_backend is { IsRunning: true }) _ = StopAsync(); else _ = StartAsync(); };
+        _open.Click += (_, _) => OpenUrl(LanUrl());
+        _copy.Click += async (_, _) => { var cb = TopLevel.GetTopLevel(this)?.Clipboard; if (cb != null) await cb.SetTextAsync(LanUrl()); };
+        _runOnLogin.IsCheckedChanged += (_, _) => SetRunOnLogin(_runOnLogin.IsChecked == true);
+
+        Content = BuildLayout();
+        UpdateUi();
+
+        // Poll the live client count / status while running (cheap; the window is tiny).
+        var timer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
+        timer.Tick += (_, _) => { if (_backend is { IsRunning: true }) UpdateUi(); };
+        timer.Start();
+    }
+
+    private Control BuildLayout()
+    {
+        var header = new StackPanel { Spacing = 2 };
+        header.Children.Add(new TextBlock { Text = "AgOpenWeb", FontSize = 22, FontWeight = FontWeight.Bold });
+        header.Children.Add(new TextBlock { Text = "Guidance host", FontSize = 12, Foreground = new SolidColorBrush(Color.Parse("#9fb3cc")) });
+
+        var statusRow = new StackPanel { Orientation = Orientation.Horizontal, Margin = new Thickness(0, 14, 0, 0) };
+        statusRow.Children.Add(_dot);
+        statusRow.Children.Add(_statusText);
+
+        var urlRow = new Grid { Margin = new Thickness(0, 10, 0, 0), ColumnDefinitions = new ColumnDefinitions("*,Auto") };
+        var urlBox = new Border
+        {
+            Background = new SolidColorBrush(Color.Parse("#1b2735")),
+            CornerRadius = new CornerRadius(4),
+            Padding = new Thickness(10, 8),
+            Child = _urlText,
+        };
+        Grid.SetColumn(urlBox, 0);
+        Grid.SetColumn(_copy, 1);
+        _copy.Margin = new Thickness(8, 0, 0, 0);
+        urlRow.Children.Add(urlBox);
+        urlRow.Children.Add(_copy);
+
+        _clientsText.Margin = new Thickness(0, 6, 0, 0);
+
+        _startStop.Classes.Add("accent");
+        var buttons = new StackPanel { Spacing = 8, Margin = new Thickness(0, 16, 0, 0) };
+        buttons.Children.Add(_startStop);
+        buttons.Children.Add(_open);
+
+        var options = new StackPanel { Spacing = 6, Margin = new Thickness(0, 16, 0, 0) };
+        options.Children.Add(_autoOpen);
+        options.Children.Add(_runOnLogin);
+
+        var root = new StackPanel { Margin = new Thickness(20) };
+        root.Children.Add(header);
+        root.Children.Add(statusRow);
+        root.Children.Add(urlRow);
+        root.Children.Add(_clientsText);
+        root.Children.Add(buttons);
+        root.Children.Add(options);
+        return root;
+    }
+
+    // ---- lifecycle ----
+
+    private async Task StartAsync()
+    {
+        if (_busy || _backend is { IsRunning: true }) return;
+        _busy = true;
+        _statusText.Text = "Starting…";
+        UpdateUi();
+        string? error = null;
+        var backend = new BackendHost();
+        try { await Task.Run(() => backend.StartAsync(_args)); _backend = backend; }
+        catch (Exception ex) { error = ex.Message; try { await backend.StopAsync(); } catch { /* best effort */ } }
+        _busy = false;
+        UpdateUi();
+        if (error != null) _statusText.Text = "Failed: " + error;
+        else if (_autoOpen.IsChecked == true) OpenUrl(LanUrl());
+    }
+
+    private async Task StopAsync()
+    {
+        if (_busy || _backend is not { IsRunning: true }) return;
+        _busy = true;
+        _statusText.Text = "Stopping…";
+        UpdateUi();
+        try { await _backend.StopAsync(); } catch { /* best effort — UI still returns to Stopped */ }
+        _backend = null;
+        _busy = false;
+        UpdateUi();
+    }
+
+    // Closing the window must stop the backend first so its ApplicationStopping save runs
+    // (config + state). Cancel the close, stop async, then close for real.
+    protected override void OnClosing(WindowClosingEventArgs e)
+    {
+        if (_backend is { IsRunning: true } && !_closing)
+        {
+            e.Cancel = true;
+            _closing = true;
+            _ = StopThenCloseAsync();
+        }
+        base.OnClosing(e);
+    }
+
+    private async Task StopThenCloseAsync()
+    {
+        try { if (_backend != null) await _backend.StopAsync(); } catch { /* close regardless */ }
+        Close();
+    }
+
+    private void UpdateUi()
+    {
+        bool running = _backend is { IsRunning: true };
+        if (!_busy)
+        {
+            _dot.Fill = new SolidColorBrush(running ? Color.Parse("#39FF6A") : Color.Parse("#ff5a5a"));
+            _statusText.Text = running ? "Running" : "Stopped";
+        }
+        else
+        {
+            _dot.Fill = new SolidColorBrush(Color.Parse("#e0b341"));
+        }
+        _startStop.Content = running ? "Stop" : "Start";
+        _startStop.IsEnabled = !_busy;
+        _open.IsEnabled = running;
+        _copy.IsEnabled = running;
+        _urlText.Text = LanUrl();
+        int clients = _backend?.Server?.ClientCount ?? 0;
+        _clientsText.Text = running ? $"{clients} browser{(clients == 1 ? "" : "s")} connected" : "";
+        _clientsText.IsVisible = running;
+    }
+
+    // ---- helpers ----
+
+    private string LanUrl()
+    {
+        int port = _backend?.Server?.Port ?? 5174;
+        return $"http://{LanIp()}:{port}";
+    }
+
+    private static string LanIp()
+    {
+        try
+        {
+            foreach (var ni in NetworkInterface.GetAllNetworkInterfaces())
+            {
+                if (ni.OperationalStatus != OperationalStatus.Up) continue;
+                if (ni.NetworkInterfaceType == NetworkInterfaceType.Loopback) continue;
+                foreach (var ua in ni.GetIPProperties().UnicastAddresses)
+                    if (ua.Address.AddressFamily == AddressFamily.InterNetwork && !IPAddress.IsLoopback(ua.Address))
+                        return ua.Address.ToString();
+            }
+        }
+        catch { /* fall through */ }
+        return "localhost";
+    }
+
+    private static void OpenUrl(string url)
+    {
+        try
+        {
+            if (OperatingSystem.IsWindows()) Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });
+            else if (OperatingSystem.IsMacOS()) Process.Start("open", url);
+            else Process.Start("xdg-open", url);
+        }
+        catch { /* no browser available — the URL is shown for manual entry */ }
+    }
+
+    // Run-on-login via reg.exe (Windows only) — package-free; the Run key launches the
+    // launcher on user sign-in. Guarded so it is never touched off Windows.
+    private static readonly string RunKey = @"HKCU\Software\Microsoft\Windows\CurrentVersion\Run";
+
+    private static void SetRunOnLogin(bool on)
+    {
+        if (!OperatingSystem.IsWindows()) return;
+        try
+        {
+            var exe = Environment.ProcessPath;
+            if (string.IsNullOrEmpty(exe)) return;
+            var psi = on
+                ? new ProcessStartInfo("reg", $"add \"{RunKey}\" /v AgOpenWeb /t REG_SZ /d \"\\\"{exe}\\\" --launcher\" /f")
+                : new ProcessStartInfo("reg", $"delete \"{RunKey}\" /v AgOpenWeb /f");
+            psi.UseShellExecute = false;
+            psi.CreateNoWindow = true;
+            Process.Start(psi)?.WaitForExit(3000);
+        }
+        catch { /* a Run-key write failure must not crash the launcher */ }
+    }
+
+    private static bool RunOnLoginEnabled()
+    {
+        if (!OperatingSystem.IsWindows()) return false;
+        try
+        {
+            var psi = new ProcessStartInfo("reg", $"query \"{RunKey}\" /v AgOpenWeb")
+            { UseShellExecute = false, RedirectStandardOutput = true, RedirectStandardError = true, CreateNoWindow = true };
+            var p = Process.Start(psi);
+            if (p == null) return false;
+            p.WaitForExit(3000);
+            return p.ExitCode == 0;
+        }
+        catch { return false; }
+    }
+
+    private void TryLoadIcon()
+    {
+        try
+        {
+            using var s = AssetLoader.Open(new Uri("avares://AgValoniaGPS.Desktop/Assets/avalonia-logo.ico"));
+            Icon = new WindowIcon(s);
+        }
+        catch { /* icon is cosmetic */ }
+    }
+}

--- a/Platforms/AgValoniaGPS.Desktop/Launcher/LauncherWindow.cs
+++ b/Platforms/AgValoniaGPS.Desktop/Launcher/LauncherWindow.cs
@@ -153,7 +153,11 @@ internal sealed class LauncherWindow : Window
         _busy = true;
         _statusText.Text = "Stopping…";
         UpdateUi();
-        try { await _backend.StopAsync(); } catch { /* best effort — UI still returns to Stopped */ }
+        // Off the UI thread: StopAsync runs blocking work (the ApplicationStopping save does a
+        // synchronous GetResult, plus host/hostLoop disposal). Awaiting it directly on the UI
+        // thread deadlocks against Avalonia's sync context — the window froze on Stop.
+        var backend = _backend;
+        try { await Task.Run(() => backend.StopAsync()); } catch { /* best effort — UI still returns to Stopped */ }
         _backend = null;
         _busy = false;
         UpdateUi();
@@ -174,7 +178,9 @@ internal sealed class LauncherWindow : Window
 
     private async Task StopThenCloseAsync()
     {
-        try { if (_backend != null) await _backend.StopAsync(); } catch { /* close regardless */ }
+        // Off the UI thread (same deadlock reason as StopAsync), then close on the UI thread.
+        var backend = _backend;
+        try { if (backend != null) await Task.Run(() => backend.StopAsync()); } catch { /* close regardless */ }
         Close();
     }
 

--- a/Platforms/AgValoniaGPS.Desktop/Launcher/LauncherWindow.cs
+++ b/Platforms/AgValoniaGPS.Desktop/Launcher/LauncherWindow.cs
@@ -133,7 +133,14 @@ internal sealed class LauncherWindow : Window
         string? error = null;
         var backend = new BackendHost();
         try { await Task.Run(() => backend.StartAsync(_args)); _backend = backend; }
-        catch (Exception ex) { error = ex.Message; try { await backend.StopAsync(); } catch { /* best effort */ } }
+        catch (Exception ex)
+        {
+            error = ex.Message;
+            // Full stack to a temp log so a Start failure on a user's box is diagnosable
+            // (a WinExe has no console to print to).
+            try { System.IO.File.WriteAllText(System.IO.Path.Combine(System.IO.Path.GetTempPath(), "agopenweb-launcher-error.log"), ex.ToString()); } catch { }
+            try { await backend.StopAsync(); } catch { /* best effort */ }
+        }
         _busy = false;
         UpdateUi();
         if (error != null) _statusText.Text = "Failed: " + error;

--- a/Platforms/AgValoniaGPS.Desktop/Program.cs
+++ b/Platforms/AgValoniaGPS.Desktop/Program.cs
@@ -40,16 +40,23 @@ sealed class Program
             return;
         }
 
-        // Phase 10: AgOpenWeb boots HEADLESS by default — no Avalonia window; the
-        // browser at http://<host>:5174 is the only UI, and the process can run as a
-        // display-less daemon (systemd / Windows Service). Pass --windowed (or set
-        // AGOPENWEB_WINDOWED=1) to launch the legacy native window for verify/compare
-        // while the headless path is field-validated. See WEBUI_SESSION_HANDOFF.md.
+        // Mode selection. The backend is identical in every mode; only how it's hosted differs:
+        //   --windowed (or AGOPENWEB_WINDOWED=1) → legacy full native UI (verify/compare).
+        //   --launcher                           → in-process launcher window (app-like).
+        //   --headless                           → display-less daemon (force, e.g. Windows Service).
+        //   no flag                              → Windows: launcher (the AgOpen audience expects a
+        //                                          program); Linux/macOS: headless daemon (systemd).
+        // The browser at http://<host>:5174 is the UI in launcher + headless modes alike.
+        // See WEBUI_SESSION_HANDOFF.md.
         bool windowed = Array.IndexOf(args, "--windowed") >= 0
             || Environment.GetEnvironmentVariable("AGOPENWEB_WINDOWED") == "1";
+        bool forceHeadless = Array.IndexOf(args, "--headless") >= 0;
+        bool forceLauncher = Array.IndexOf(args, "--launcher") >= 0;
 
         if (windowed)
             BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
+        else if (forceLauncher || (OperatingSystem.IsWindows() && !forceHeadless))
+            Launcher.LauncherEntry.Run(args);
         else
             HeadlessHost.RunAsync(args).GetAwaiter().GetResult();
     }

--- a/Shared/AgValoniaGPS.RemoteServer/RemoteServerHost.cs
+++ b/Shared/AgValoniaGPS.RemoteServer/RemoteServerHost.cs
@@ -22,6 +22,13 @@ public sealed class RemoteServerHost
     private WebSocketHub? _ws;
     private MapBroadcaster? _broadcaster;
 
+    /// <summary>The TCP port the server is bound on (set by StartAsync). For the launcher
+    /// UI's "browse to …" readout.</summary>
+    public int Port { get; private set; } = 5174;
+
+    /// <summary>Number of connected browser clients — drives the launcher's live status.</summary>
+    public int ClientCount => _ws?.ClientCount ?? 0;
+
     // Satellite tile fetch (Phase MT — Draw boundary on map). Keyless Bing aerial
     // tiles via the Virtual Earth quadkey endpoint (same source as native's
     // BoundaryMapDialog). Proxied through the host so the browser draws them into the
@@ -130,6 +137,7 @@ public sealed class RemoteServerHost
         INtripProfileService ntripProfiles, IFieldService fields, ISettingsService settings,
         IVehicleProfileService vehicleProfiles, IPersistentStateService persist, int port = 5174)
     {
+        Port = port;
         var builder = WebApplication.CreateBuilder();
         builder.WebHost.UseUrls($"http://0.0.0.0:{port}");
         builder.Logging.AddFilter("Microsoft.AspNetCore", LogLevel.Warning);

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Navigation.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Navigation.cs
@@ -281,11 +281,17 @@ public partial class MainViewModel
     /// </summary>
     internal static void ApplyThemeVariant(bool isDayMode)
     {
-        if (Application.Current != null)
-        {
-            Application.Current.RequestedThemeVariant = isDayMode
-                ? ThemeVariant.Light
-                : ThemeVariant.Dark;
-        }
+        var app = Application.Current;
+        if (app == null) return; // headless daemon — no Avalonia Application to theme
+
+        var variant = isDayMode ? ThemeVariant.Light : ThemeVariant.Dark;
+        // RequestedThemeVariant is UI-thread-affine. The windowed App calls this on the UI
+        // thread (direct set); the in-process launcher constructs the VM on a worker thread
+        // while an Avalonia Application IS live, so marshal to the UI thread there instead of
+        // throwing "calling thread cannot access this object".
+        if (Avalonia.Threading.Dispatcher.UIThread.CheckAccess())
+            app.RequestedThemeVariant = variant;
+        else
+            Avalonia.Threading.Dispatcher.UIThread.Post(() => app.RequestedThemeVariant = variant);
     }
 }

--- a/deploy/windows/README.md
+++ b/deploy/windows/README.md
@@ -1,0 +1,27 @@
+# AgOpenWeb — Windows
+
+App-like launcher for the **headless** AgOpenWeb guidance host. Unlike the Linux daemon
+(`deploy/linux`), Windows runs as a normal program you start and stop yourself.
+
+## Run
+
+1. Extract the zip anywhere (e.g. `C:\AgOpenWeb`).
+2. Double-click **`AgValoniaGPS.Desktop.exe`**.
+3. In the launcher window, click **Start**. The browser opens to the web UI automatically
+   (uncheck "Open browser when started" to disable). Click **Open in Browser** any time.
+4. To connect a tablet/phone in the cab, browse the other device to the **LAN URL** shown
+   in the window (e.g. `http://192.168.1.50:5174`) — use the **Copy** button.
+
+It's self-contained — no .NET install needed.
+
+## Notes
+
+- **Closing the window stops the host** and saves your config + field state first.
+- **Start with Windows** (checkbox) launches the app on sign-in (per-user; uses the
+  `HKCU\…\Run` key). Untick to remove.
+- Field data, vehicles, tools and config live under your Documents folder
+  (`Documents\AgValoniaGPS`), so they survive replacing the program folder on update.
+- The launcher hosts the backend **in-process**; there is no separate service. To run it
+  display-less as a background daemon instead, start the exe with `--headless`.
+- This same exe is the cross-platform app: `--windowed` opens the legacy native UI,
+  `--launcher` forces the launcher on any OS.

--- a/deploy/windows/package.sh
+++ b/deploy/windows/package.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# AgOpenWeb — build a deployable Windows bundle (Phase 10 launcher).
+#
+# Cross-publishes the self-contained Desktop exe on a build machine (dev Mac / Linux / CI)
+# and zips it. On Windows the user just extracts and double-clicks AgValoniaGPS.Desktop.exe:
+# no args → the in-process launcher window (Start / Stop / Open in Browser). No installer,
+# no service, no .NET install needed — it's app-like, the way the Windows AgOpen audience
+# expects. (Linux/macOS use deploy/linux instead.)
+#
+# Usage:
+#   ./package.sh                  # win-x64 bundle (default)
+#   ./package.sh --arch arm64     # win-arm64 bundle (Windows on ARM)
+#   ./package.sh --out /tmp       # choose output dir
+#
+# Requires: bash + the .NET 10 SDK. Runs anywhere dotnet can cross-publish.
+
+set -euo pipefail
+
+ARCH="x64"
+OUT_DIR="$(pwd)"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --arch) ARCH="$2"; shift 2 ;;
+    --out) OUT_DIR="$2"; shift 2 ;;
+    -h|--help) sed -n '2,18p' "$0"; exit 0 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+case "$ARCH" in
+  x64|amd64)     RID="win-x64" ;;
+  arm64|aarch64) RID="win-arm64" ;;
+  *) echo "error: unsupported --arch '$ARCH' (use x64 or arm64)" >&2; exit 2 ;;
+esac
+
+command -v dotnet >/dev/null || { echo "error: dotnet SDK not found" >&2; exit 1; }
+command -v zip >/dev/null || { echo "error: zip not found" >&2; exit 1; }
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+CSPROJ="$REPO_ROOT/Platforms/AgValoniaGPS.Desktop/AgValoniaGPS.Desktop.csproj"
+
+NAME="agopenweb-$RID"
+STAGE="$(mktemp -d)/$NAME"
+mkdir -p "$STAGE"
+
+echo "==> Publishing self-contained $RID (no trim — the app uses reflection)…"
+# DesktopOnly=true collapses the shared projects' net10.0;net10.0-ios multi-target to
+# net10.0 so a cross-publish doesn't try to pull the iOS/Mono runtime packs (NU1102).
+dotnet publish "$CSPROJ" \
+  -c Release -r "$RID" --self-contained true \
+  -p:DesktopOnly=true \
+  -p:PublishTrimmed=false -p:PublishSingleFile=false \
+  -o "$STAGE"
+
+cp "$SCRIPT_DIR/README.md" "$STAGE/" 2>/dev/null || true
+
+# Strip debug symbols — not needed at runtime. SkiaSharp ships an ~84 MB native
+# libSkiaSharp.pdb that otherwise dominates the zip.
+find "$STAGE" -name '*.pdb' -delete
+
+mkdir -p "$OUT_DIR"
+ZIP="$OUT_DIR/$NAME.zip"
+echo "==> Writing ${ZIP} ..."
+rm -f "$ZIP"
+( cd "$(dirname "$STAGE")" && zip -r -q "$ZIP" "$NAME" )
+rm -rf "$(dirname "$STAGE")"
+
+echo "==> Done: $ZIP ($(du -h "$ZIP" | cut -f1))"
+echo
+echo "On Windows: extract the zip and run AgValoniaGPS.Desktop.exe — the launcher opens."

--- a/sys/version.h
+++ b/sys/version.h
@@ -5,7 +5,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 6
-#define VERSION_PATCH 4
+#define VERSION_PATCH 5
 
-#define VERSION "26.6.4"
+#define VERSION "26.6.5"
 #define VERSION_DATE "2026-06-21"

--- a/sys/version.h
+++ b/sys/version.h
@@ -5,7 +5,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 6
-#define VERSION_PATCH 6
+#define VERSION_PATCH 7
 
-#define VERSION "26.6.6"
+#define VERSION "26.6.7"
 #define VERSION_DATE "2026-06-21"

--- a/sys/version.h
+++ b/sys/version.h
@@ -5,7 +5,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 6
-#define VERSION_PATCH 5
+#define VERSION_PATCH 6
 
-#define VERSION "26.6.5"
+#define VERSION "26.6.6"
 #define VERSION_DATE "2026-06-21"


### PR DESCRIPTION
## What
An **app-like Windows launcher** for the headless host. Windows users expect a program with buttons, not a systemd daemon — so this is a small window that **starts/stops the guidance backend in-process** and **opens the web UI in the default browser**. It's the on-ramp for the Windows-heavy AgOpen audience; Linux keeps the systemd unit.

Windows is the wrong *appliance* OS, but a great *convenience* target — and this is packaging, not porting, since the host is already cross-platform .NET.

## How
- **`BackendHost`** — extracted the DI build + control loops + RemoteServer start/wire + clean `ApplicationStopping` save out of `HeadlessHost`, so the daemon and the launcher drive **one** lifecycle (`StartAsync`/`StopAsync`). `HeadlessHost` is now a thin daemon wrapper. Verified the daemon path is byte-for-byte behaviorally identical (boot, serve HTTP 200, save-on-stop, clean exit).
- **Launcher** (`LauncherApplication` / `LauncherWindow` / `LauncherEntry`) — a minimal Avalonia app (not the full map `App`). Status dot + LAN URL + Copy, Start/Stop, Open in Browser, auto-open-on-start, and "Start with Windows" (run-on-login via `reg.exe`, Windows-only). Closing the window stops the backend first so config + state save. The backend runs on its own host-loop thread; the window is just the supervisor.
- **Mode select** in `Program.cs`: `--windowed` = full native UI; `--launcher` = launcher; `--headless` = force daemon; **no flag → Windows: launcher, Linux/macOS: headless daemon** (the systemd default is unchanged).
- **`RemoteServerHost`** exposes `Port` + `ClientCount` for the launcher's live readout.

Naturally cross-platform — `--launcher` gives macOS/Linux an app-like alternative to the service, for free.

## Verification
- Desktop builds clean (Debug).
- Headless backend (the shared `BackendHost`) boots, serves HTTP 200 on :5174, fires the config+state save on SIGTERM, and exits cleanly — refactor preserves daemon behavior.
- Launcher window constructs with no exceptions.
- Full interactive Start → Open Browser flow to be confirmed on Windows (the target).

## Notes
- Ships automatically in the existing `win-x64` build (no-arg on Windows now opens the launcher).
- A **system tray icon** (minimize-to-tray, quick Start/Stop/Open) is the obvious next polish — left out of this PR to keep it focused; easy follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)