### PR TITLE
Android UDP interface-discovery fix (sync AgValoniaGPS #480)

### DIFF
--- a/Platforms/AgValoniaGPS.Android/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Platforms/AgValoniaGPS.Android/DependencyInjection/ServiceCollectionExtensions.cs
@@ -71,6 +71,10 @@ public static class ServiceCollectionExtensions
         services.AddTransient<ConfigurationViewModel>();
 
         // Register Services
+        services.AddSingleton<ILocalNetworkInfoProvider>(_ =>
+            new AndroidLocalNetworkInfoProvider(
+                global::Android.App.Application.Context
+                ?? throw new InvalidOperationException("Android application context is unavailable.")));
         services.AddSingleton<IUdpCommunicationService, UdpCommunicationService>();
 
         // Core services

--- a/Platforms/AgValoniaGPS.Android/Properties/AndroidManifest.xml
+++ b/Platforms/AgValoniaGPS.Android/Properties/AndroidManifest.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+  <uses-permission android:name="android.permission.INTERNET" />
+  <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+</manifest>

--- a/Platforms/AgValoniaGPS.Android/Services/AndroidLocalNetworkInfoProvider.cs
+++ b/Platforms/AgValoniaGPS.Android/Services/AndroidLocalNetworkInfoProvider.cs
@@ -1,0 +1,81 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2026 AgValoniaGPS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Sockets;
+using Android.Content;
+using AgValoniaGPS.Services.Interfaces;
+using ConnectivityManager = Android.Net.ConnectivityManager;
+
+namespace AgValoniaGPS.Android.Services;
+
+/// <summary>
+/// Reads local link addresses from Android's ConnectivityManager.
+/// System.Net.NetworkInformation can return no interfaces on some Android
+/// devices even while Wi-Fi or USB Ethernet is connected.
+/// </summary>
+public sealed class AndroidLocalNetworkInfoProvider : ILocalNetworkInfoProvider
+{
+    private readonly ConnectivityManager? _connectivityManager;
+
+    public AndroidLocalNetworkInfoProvider(Context context)
+    {
+        _connectivityManager =
+            context.GetSystemService(Context.ConnectivityService) as ConnectivityManager;
+    }
+
+    public IReadOnlyList<LocalNetworkAddress> GetIPv4Addresses()
+    {
+        var addresses = new List<LocalNetworkAddress>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+
+        try
+        {
+            var networks = _connectivityManager?.GetAllNetworks();
+            if (networks is null) return addresses;
+
+            foreach (var network in networks)
+            {
+                var properties = _connectivityManager?.GetLinkProperties(network);
+                if (properties is null) continue;
+
+                foreach (var linkAddress in properties.LinkAddresses)
+                {
+                    var hostAddress =linkAddress.Address?.HostAddress;
+                    if (string.IsNullOrWhiteSpace(hostAddress)) continue;
+
+                    // IPv6 addresses may contain a scope suffix such as "%wlan0".
+                    int scopeIndex = hostAddress.IndexOf('%');
+                    if (scopeIndex >= 0)
+                        hostAddress = hostAddress[..scopeIndex];
+
+                    if (!IPAddress.TryParse(hostAddress, out var address)) continue;
+                    if (address.AddressFamily != AddressFamily.InterNetwork) continue;
+                    if (IPAddress.IsLoopback(address)) continue;
+
+                    var addressText = address.ToString();
+                    if (!seen.Add(addressText)) continue;
+
+                    addresses.Add(new LocalNetworkAddress(
+                        address,
+                        linkAddress.PrefixLength,
+                        properties.InterfaceName));
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine(
+                $"Failed to enumerate Android network links: {ex.Message}");
+        }
+
+        return addresses;
+    }
+}

--- a/Platforms/AgValoniaGPS.Android/Services/AndroidLocalNetworkInfoProvider.cs
+++ b/Platforms/AgValoniaGPS.Android/Services/AndroidLocalNetworkInfoProvider.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.Net;
 using System.Net.Sockets;
 using Android.Content;
+using Android.Net;
 using AgValoniaGPS.Services.Interfaces;
 using ConnectivityManager = Android.Net.ConnectivityManager;
 
@@ -43,12 +44,25 @@ public sealed class AndroidLocalNetworkInfoProvider : ILocalNetworkInfoProvider
 
             foreach (var network in networks)
             {
+                var capabilities = _connectivityManager?.GetNetworkCapabilities(network);
+                if (capabilities is null)
+                    continue;
+
+                bool isLan =
+                    capabilities.HasTransport(TransportType.Wifi) ||
+                    capabilities.HasTransport(TransportType.Ethernet);
+
+                if (!isLan)
+                    continue;
+
                 var properties = _connectivityManager?.GetLinkProperties(network);
-                if (properties is null) continue;
+                if (properties is null)
+                    continue;
+
 
                 foreach (var linkAddress in properties.LinkAddresses)
                 {
-                    var hostAddress =linkAddress.Address?.HostAddress;
+                    var hostAddress = linkAddress.Address?.HostAddress;
                     if (string.IsNullOrWhiteSpace(hostAddress)) continue;
 
                     // IPv6 addresses may contain a scope suffix such as "%wlan0".

--- a/Platforms/AgValoniaGPS.Desktop/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Platforms/AgValoniaGPS.Desktop/DependencyInjection/ServiceCollectionExtensions.cs
@@ -71,6 +71,7 @@ public static class ServiceCollectionExtensions
         services.AddTransient<ConfigurationViewModel>();
 
         // Register Services
+        services.AddSingleton<ILocalNetworkInfoProvider, SystemLocalNetworkInfoProvider>();
         services.AddSingleton<IUdpCommunicationService, UdpCommunicationService>();
 
         // Core services

--- a/Platforms/AgValoniaGPS.iOS/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Platforms/AgValoniaGPS.iOS/DependencyInjection/ServiceCollectionExtensions.cs
@@ -71,6 +71,7 @@ public static class ServiceCollectionExtensions
         services.AddTransient<ConfigurationViewModel>();
 
         // Register Services
+        services.AddSingleton<ILocalNetworkInfoProvider, SystemLocalNetworkInfoProvider>();
         services.AddSingleton<IUdpCommunicationService, UdpCommunicationService>();
 
         // Core services

--- a/Shared/AgValoniaGPS.Services/Interfaces/ILocalNetworkInfoProvider.cs
+++ b/Shared/AgValoniaGPS.Services/Interfaces/ILocalNetworkInfoProvider.cs
@@ -1,0 +1,31 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2026 AgValoniaGPS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+using System.Collections.Generic;
+using System.Net;
+
+namespace AgValoniaGPS.Services.Interfaces;
+
+/// <summary>
+/// One IPv4 address assigned to a local network link.
+/// </summary>
+public sealed record LocalNetworkAddress(
+    IPAddress Address,
+    int PrefixLength,
+    string? InterfaceName = null);
+
+/// <summary>
+/// Platform abstraction for local IPv4 interface discovery.
+/// Android does not reliably populate System.Net.NetworkInformation on all
+/// devices, so its application target supplies a ConnectivityManager-backed
+/// implementation.
+/// </summary>
+public interface ILocalNetworkInfoProvider
+{
+    IReadOnlyList<LocalNetworkAddress> GetIPv4Addresses();
+}

--- a/Shared/AgValoniaGPS.Services/SystemLocalNetworkInfoProvider.cs
+++ b/Shared/AgValoniaGPS.Services/SystemLocalNetworkInfoProvider.cs
@@ -1,0 +1,75 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2026 AgValoniaGPS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.NetworkInformation;
+using System.Net.Sockets;
+using AgValoniaGPS.Services.Interfaces;
+
+namespace AgValoniaGPS.Services;
+
+/// <summary>
+/// Local network discovery for desktop platforms and as the default provider.
+/// </summary>
+public sealed class SystemLocalNetworkInfoProvider : ILocalNetworkInfoProvider
+{
+    public IReadOnlyList<LocalNetworkAddress> GetIPv4Addresses()
+    {
+        var addresses = new List<LocalNetworkAddress>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+
+        try
+        {
+            foreach (var nic in NetworkInterface.GetAllNetworkInterfaces())
+            {
+                if (nic.OperationalStatus != OperationalStatus.Up) continue;
+                if (!nic.Supports(NetworkInterfaceComponent.IPv4)) continue;
+
+                foreach (var unicast in nic.GetIPProperties().UnicastAddresses)
+                {
+                    if (unicast.Address.AddressFamily != AddressFamily.InterNetwork) continue;
+                    if (IPAddress.IsLoopback(unicast.Address)) continue;
+                    if (unicast.IPv4Mask is null) continue;
+
+                    var addressText = unicast.Address.ToString();
+                    if (!seen.Add(addressText)) continue;
+
+                    addresses.Add(new LocalNetworkAddress(
+                        unicast.Address,
+                        GetPrefixLength(unicast.IPv4Mask),
+                        nic.Name));
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine(
+                $"Failed to enumerate system network interfaces: {ex.Message}");
+        }
+
+        return addresses;
+    }
+
+    internal static int GetPrefixLength(IPAddress subnetMask)
+    {
+        int prefixLength = 0;
+        foreach (byte value in subnetMask.GetAddressBytes())
+        {
+            byte current = value;
+            for (int bit = 0; bit < 8; bit++)
+            {
+                prefixLength += current >> 7;
+                current <<= 1;
+            }
+        }
+
+        return prefixLength;
+    }
+}

--- a/Shared/AgValoniaGPS.Services/UdpCommunicationService.cs
+++ b/Shared/AgValoniaGPS.Services/UdpCommunicationService.cs
@@ -18,7 +18,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
-using System.Net.NetworkInformation;
 using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
@@ -43,6 +42,7 @@ public class UdpCommunicationService : IUdpCommunicationService, IDisposable
     public event EventHandler<ModuleConnectionEventArgs>? ModuleConnectionChanged;
 
     private Socket? _udpSocket;
+    private readonly ILocalNetworkInfoProvider _localNetworkInfoProvider;
     private readonly byte[] _receiveBuffer = new byte[1024];
     private EndPoint _remoteEndPoint = new IPEndPoint(IPAddress.Any, 0);
     private CancellationTokenSource? _cancellationTokenSource;
@@ -88,6 +88,12 @@ public class UdpCommunicationService : IUdpCommunicationService, IDisposable
 
     public bool IsConnected { get; private set; }
     public string? LocalIPAddress { get; private set; }
+
+    public UdpCommunicationService(ILocalNetworkInfoProvider localNetworkInfoProvider)
+    {
+        _localNetworkInfoProvider = localNetworkInfoProvider
+            ?? throw new ArgumentNullException(nameof(localNetworkInfoProvider));
+    }
 
     /// <summary>
     /// Register the AutoSteer service for zero-copy GPS processing.
@@ -565,31 +571,22 @@ public class UdpCommunicationService : IUdpCommunicationService, IDisposable
         var dest = new IPEndPoint(IPAddress.Broadcast, 8888);
         try
         {
-            foreach (var nic in NetworkInterface.GetAllNetworkInterfaces())
+            foreach (var localAddress in _localNetworkInfoProvider.GetIPv4Addresses())
             {
-                if (nic.OperationalStatus != OperationalStatus.Up) continue;
-                if (!nic.Supports(NetworkInterfaceComponent.IPv4)) continue;
-
-                foreach (var addr in nic.GetIPProperties().UnicastAddresses)
+                try
                 {
-                    if (addr.Address.AddressFamily != AddressFamily.InterNetwork) continue;
-                    if (IPAddress.IsLoopback(addr.Address)) continue;
-
-                    try
-                    {
-                        // Bind a transient socket to this NIC so the broadcast
-                        // actually egresses it (multi-homed tablets), exactly as
-                        // AgIO does. ReuseAddress lets us co-bind :9999 with the
-                        // main receive socket; replies still arrive on it.
-                        using var s = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
-                        s.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.Broadcast, true);
-                        s.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
-                        s.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.DontRoute, true);
-                        s.Bind(new IPEndPoint(addr.Address, 9999));
-                        s.SendTo(data, dest);
-                    }
-                    catch { }
+                    // Bind a transient socket to this link so the broadcast
+                    // actually egresses it (multi-homed tablets), exactly as
+                    // AgIO does. ReuseAddress lets us co-bind :9999 with the
+                    // main receive socket; replies still arrive on it.
+                    using var s = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+                    s.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.Broadcast, true);
+                    s.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
+                    s.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.DontRoute, true);
+                    s.Bind(new IPEndPoint(localAddress.Address, 9999));
+                    s.SendTo(data, dest);
                 }
+                catch { }
             }
         }
         catch (Exception ex)
@@ -632,35 +629,21 @@ public class UdpCommunicationService : IUdpCommunicationService, IDisposable
     /// Enumerate broadcast addresses for all active IPv4 network interfaces.
     /// Always includes localhost for simulator support.
     /// </summary>
-    private static List<IPEndPoint> GetBroadcastEndpoints()
+    private List<IPEndPoint> GetBroadcastEndpoints()
     {
         var endpoints = new List<IPEndPoint> { _localhostEndpoint };
+        var seen = new HashSet<string>(StringComparer.Ordinal)
+        {
+            _localhostEndpoint.ToString()
+        };
 
         try
         {
-            foreach (var nic in NetworkInterface.GetAllNetworkInterfaces())
+            foreach (var localAddress in _localNetworkInfoProvider.GetIPv4Addresses())
             {
-                if (nic.OperationalStatus != OperationalStatus.Up)
-                    continue;
-                if (!nic.Supports(NetworkInterfaceComponent.IPv4))
-                    continue;
-
-                foreach (var addr in nic.GetIPProperties().UnicastAddresses)
-                {
-                    if (addr.Address.AddressFamily != AddressFamily.InterNetwork)
-                        continue;
-                    if (IPAddress.IsLoopback(addr.Address))
-                        continue;
-
-                    // Calculate broadcast: IP | ~SubnetMask
-                    var ipBytes = addr.Address.GetAddressBytes();
-                    var maskBytes = addr.IPv4Mask.GetAddressBytes();
-                    var broadcastBytes = new byte[4];
-                    for (int i = 0; i < 4; i++)
-                        broadcastBytes[i] = (byte)(ipBytes[i] | ~maskBytes[i]);
-
-                    endpoints.Add(new IPEndPoint(new IPAddress(broadcastBytes), 8888));
-                }
+                var endpoint = new IPEndPoint(CalculateBroadcastAddress(localAddress), 8888);
+                if (seen.Add(endpoint.ToString()))
+                    endpoints.Add(endpoint);
             }
         }
         catch (Exception ex)
@@ -671,22 +654,41 @@ public class UdpCommunicationService : IUdpCommunicationService, IDisposable
         return endpoints;
     }
 
+    internal static IPAddress CalculateBroadcastAddress(LocalNetworkAddress localAddress)
+    {
+        if (localAddress.Address.AddressFamily != AddressFamily.InterNetwork)
+            throw new ArgumentException("Only IPv4 addresses are supported.", nameof(localAddress));
+        if (localAddress.PrefixLength is < 0 or > 32)
+            throw new ArgumentOutOfRangeException(
+                nameof(localAddress),
+                "IPv4 prefix length must be between 0 and 32.");
+
+        uint ip = NetworkToHostUInt32(localAddress.Address.GetAddressBytes());
+        uint mask = localAddress.PrefixLength == 0
+            ? 0
+            : uint.MaxValue << (32 - localAddress.PrefixLength);
+        uint broadcast = ip | ~mask;
+
+        return new IPAddress(new[]
+        {
+            (byte)(broadcast >> 24),
+            (byte)(broadcast >> 16),
+            (byte)(broadcast >> 8),
+            (byte)broadcast
+        });
+    }
+
+    private static uint NetworkToHostUInt32(byte[] bytes) =>
+        ((uint)bytes[0] << 24)
+        | ((uint)bytes[1] << 16)
+        | ((uint)bytes[2] << 8)
+        | bytes[3];
+
     private string? GetLocalIPAddress()
     {
-        try
-        {
-            var host = Dns.GetHostEntry(Dns.GetHostName());
-            foreach (var ip in host.AddressList)
-            {
-                if (ip.AddressFamily == AddressFamily.InterNetwork)
-                {
-                    return ip.ToString();
-                }
-            }
-        }
-        catch { }
-
-        return null;
+        return _localNetworkInfoProvider.GetIPv4Addresses()
+            .Select(address => address.Address.ToString())
+            .FirstOrDefault();
     }
 
     /// <summary>
@@ -696,25 +698,10 @@ public class UdpCommunicationService : IUdpCommunicationService, IDisposable
     /// </summary>
     public IReadOnlyList<string> GetLocalIpAddresses()
     {
-        var list = new List<string>();
-        try
-        {
-            foreach (var nic in NetworkInterface.GetAllNetworkInterfaces())
-            {
-                if (nic.OperationalStatus != OperationalStatus.Up) continue;
-                if (!nic.Supports(NetworkInterfaceComponent.IPv4)) continue;
-
-                foreach (var addr in nic.GetIPProperties().UnicastAddresses)
-                {
-                    if (addr.Address.AddressFamily != AddressFamily.InterNetwork) continue;
-                    if (IPAddress.IsLoopback(addr.Address)) continue;
-                    var s = addr.Address.ToString();
-                    if (!list.Contains(s)) list.Add(s);
-                }
-            }
-        }
-        catch { }
-        return list;
+        return _localNetworkInfoProvider.GetIPv4Addresses()
+            .Select(address => address.Address.ToString())
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
     }
 
     public void Dispose()

--- a/Tests/AgValoniaGPS.Services.Tests/UdpNetworkAddressTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/UdpNetworkAddressTests.cs
@@ -1,0 +1,53 @@
+using System.Net;
+using AgValoniaGPS.Services;
+using AgValoniaGPS.Services.Interfaces;
+
+namespace AgValoniaGPS.Services.Tests;
+
+[TestFixture]
+public class UdpNetworkAddressTests
+{
+    [TestCase("192.168.5.42", 24, "192.168.5.255")]
+    [TestCase("10.20.33.8", 16, "10.20.255.255")]
+    [TestCase("172.16.4.9", 20, "172.16.15.255")]
+    [TestCase("192.168.5.42", 32, "192.168.5.42")]
+    public void CalculateBroadcastAddress_UsesPrefixLength(
+        string address,
+        int prefixLength,
+        string expected)
+    {
+        var localAddress = new LocalNetworkAddress(
+            IPAddress.Parse(address),
+            prefixLength);
+
+        var actual = UdpCommunicationService.CalculateBroadcastAddress(localAddress);
+
+        Assert.That(actual.ToString(), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void GetLocalIpAddresses_UsesInjectedProviderAndRemovesDuplicates()
+    {
+        var provider = new FakeLocalNetworkInfoProvider(
+            new LocalNetworkAddress(IPAddress.Parse("192.168.5.20"), 24, "wlan0"),
+            new LocalNetworkAddress(IPAddress.Parse("192.168.5.20"), 24, "wlan0"),
+            new LocalNetworkAddress(IPAddress.Parse("10.0.0.4"), 24, "eth0"));
+        var service = new UdpCommunicationService(provider);
+
+        Assert.That(
+            service.GetLocalIpAddresses(),
+            Is.EqualTo(new[] { "192.168.5.20", "10.0.0.4" }));
+    }
+
+    private sealed class FakeLocalNetworkInfoProvider : ILocalNetworkInfoProvider
+    {
+        private readonly IReadOnlyList<LocalNetworkAddress> _addresses;
+
+        public FakeLocalNetworkInfoProvider(params LocalNetworkAddress[] addresses)
+        {
+            _addresses = addresses;
+        }
+
+        public IReadOnlyList<LocalNetworkAddress> GetIPv4Addresses() => _addresses;
+    }
+}


### PR DESCRIPTION
Syncs the Android UDP communication fix merged upstream in AgOpenGPS-Official/AgValoniaGPS#480 (fixes the issue where `NetworkInterface.GetAllNetworkInterfaces()` returns no interfaces on some Android devices, so broadcast/module discovery collapsed to localhost and the app never connected even though packets were arriving).

## What it brings
- New `ILocalNetworkInfoProvider` platform abstraction for IPv4 interface discovery.
- `SystemLocalNetworkInfoProvider` (Desktop/iOS) over `NetworkInterface`; `AndroidLocalNetworkInfoProvider` over `ConnectivityManager`, **transport-filtered to Wi-Fi/Ethernet** (cellular/VPN excluded).
- `UdpCommunicationService` refactored to the injected provider; prefix-length-based broadcast calculation.
- DI registration across all three platforms; Android network permissions.

## Verification
- Desktop build: clean (warnings only).
- Full service test suite: 994 passed, 0 failed.
- Reviewed + merged upstream as #480.

Follow-up: additional unit-test cases (broadcast `/0` + validation paths) will come in a separate PR.