### PR TITLE
Add UDP broadcast-address edge-case tests (sync AgValoniaGPS #481)

### DIFF
--- a/Tests/AgValoniaGPS.Services.Tests/UdpNetworkAddressTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/UdpNetworkAddressTests.cs
@@ -11,6 +11,7 @@ public class UdpNetworkAddressTests
     [TestCase("10.20.33.8", 16, "10.20.255.255")]
     [TestCase("172.16.4.9", 20, "172.16.15.255")]
     [TestCase("192.168.5.42", 32, "192.168.5.42")]
+    [TestCase("192.168.5.42", 0, "255.255.255.255")]
     public void CalculateBroadcastAddress_UsesPrefixLength(
         string address,
         int prefixLength,
@@ -23,6 +24,31 @@ public class UdpNetworkAddressTests
         var actual = UdpCommunicationService.CalculateBroadcastAddress(localAddress);
 
         Assert.That(actual.ToString(), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void CalculateBroadcastAddress_RejectsNonIPv4Address()
+    {
+        var localAddress = new LocalNetworkAddress(
+            IPAddress.Parse("fe80::1"),
+            64);
+
+        Assert.That(
+            () => UdpCommunicationService.CalculateBroadcastAddress(localAddress),
+            Throws.ArgumentException);
+    }
+
+    [TestCase(-1)]
+    [TestCase(33)]
+    public void CalculateBroadcastAddress_RejectsOutOfRangePrefixLength(int prefixLength)
+    {
+        var localAddress = new LocalNetworkAddress(
+            IPAddress.Parse("192.168.5.42"),
+            prefixLength);
+
+        Assert.That(
+            () => UdpCommunicationService.CalculateBroadcastAddress(localAddress),
+            Throws.TypeOf<ArgumentOutOfRangeException>());
     }
 
     [Test]


### PR DESCRIPTION
Syncs the follow-up test coverage merged upstream in AgOpenGPS-Official/AgValoniaGPS#481.

Adds unit tests for `UdpCommunicationService.CalculateBroadcastAddress`: `/0` prefix special case, non-IPv4 `ArgumentException`, and out-of-range prefix `ArgumentOutOfRangeException`. No production code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)