### PR TITLE
VSim: PANDA/PAOGI + IMU/WAS controls + data panes; #478 regression tests

### DIFF
--- a/Simulators/AgValoniaGPS.VehicleSimulator/Modules/PgnProtocol.cs
+++ b/Simulators/AgValoniaGPS.VehicleSimulator/Modules/PgnProtocol.cs
@@ -95,6 +95,20 @@ public static class PgnProtocol
     public static byte GetPgn(byte[] data) => data[3];
 
     /// <summary>
+    /// Human-readable one-line description of a PGN frame for the sim's
+    /// sent/received data panes: "PGN nnn: 80 81 .. .." for valid headers,
+    /// raw hex otherwise.
+    /// </summary>
+    public static string Describe(byte[] data, int length)
+    {
+        if (length <= 0) return "(empty)";
+        string hex = BitConverter.ToString(data, 0, length).Replace('-', ' ');
+        if (length >= 4 && data[0] == 0x80 && data[1] == 0x81)
+            return $"PGN {data[3],3}: {hex}";
+        return hex;
+    }
+
+    /// <summary>
     /// Extract data length from a valid packet.
     /// </summary>
     public static byte GetDataLength(byte[] data) => data[4];

--- a/Simulators/AgValoniaGPS.VehicleSimulator/Modules/VirtualGpsReceiver.cs
+++ b/Simulators/AgValoniaGPS.VehicleSimulator/Modules/VirtualGpsReceiver.cs
@@ -17,8 +17,18 @@ using System.Threading.Tasks;
 namespace AgValoniaGPS.VehicleSimulator.Modules;
 
 /// <summary>
-/// Virtual GPS receiver that sends $PANDA NMEA sentences via UDP.
-/// Supports single and dual antenna configurations.
+/// GPS message flavour. PANDA = single antenna + IMU (heading/roll as int×10,
+/// 65535 = no-IMU sentinel). PAOGI = dual antenna (heading/roll as floats).
+/// </summary>
+public enum GpsMessageType
+{
+    Panda,
+    Paogi
+}
+
+/// <summary>
+/// Virtual GPS receiver that sends $PANDA (single) or $PAOGI (dual) NMEA
+/// sentences via UDP, matching the AiO firmware wire format.
 /// </summary>
 public class VirtualGpsReceiver : IDisposable
 {
@@ -38,10 +48,17 @@ public class VirtualGpsReceiver : IDisposable
     public double Hdop { get; set; } = 0.7;
     public double DifferentialAge { get; set; } = 1.0;
 
-    // IMU data (embedded in $PANDA)
+    // IMU data (embedded in $PANDA / $PAOGI)
     public double RollDegrees { get; set; }
     public double PitchDegrees { get; set; }
     public double YawRateDegPerSec { get; set; }
+
+    /// <summary>PANDA only: when false, the heading field is sent as the 65535
+    /// "no-IMU" sentinel so the host's ImuValid=false branch can be exercised.</summary>
+    public bool ImuValid { get; set; } = true;
+
+    /// <summary>Wire format: PANDA (single+IMU) or PAOGI (dual antenna).</summary>
+    public GpsMessageType MessageType { get; set; } = GpsMessageType.Panda;
 
     // Dual antenna
     public bool IsDualAntenna { get; set; }
@@ -52,6 +69,9 @@ public class VirtualGpsReceiver : IDisposable
 
     // Counters for test verification
     public long SentCount { get; private set; }
+
+    /// <summary>Fired with each outgoing NMEA sentence (for the sim's Sent pane).</summary>
+    public Action<string>? OnSent;
 
     public VirtualGpsReceiver(int targetPort = 9999, string targetIp = "127.0.0.1")
     {
@@ -72,14 +92,16 @@ public class VirtualGpsReceiver : IDisposable
     }
 
     /// <summary>
-    /// Send a single $PANDA sentence immediately (for test control).
+    /// Send a single GPS sentence immediately (for test control). PANDA or
+    /// PAOGI depending on <see cref="MessageType"/>.
     /// </summary>
     public void SendOnce()
     {
-        var sentence = BuildPandaSentence();
+        var sentence = BuildSentence();
         var bytes = Encoding.ASCII.GetBytes(sentence);
         _udp.Send(bytes, bytes.Length, _target);
         SentCount++;
+        OnSent?.Invoke(sentence.TrimEnd('\r', '\n'));
     }
 
     /// <summary>
@@ -112,44 +134,67 @@ public class VirtualGpsReceiver : IDisposable
         }
     }
 
-    private string BuildPandaSentence()
+    private string BuildSentence()
     {
-        // Format: $PANDA,time,lat,N/S,lon,E/W,fix,sats,hdop,alt,age,speed,heading,roll,pitch,yaw*checksum
-        string time = DateTime.UtcNow.ToString("HHmmss.ff", CultureInfo.InvariantCulture);
+        // Shared layout (both flavours):
+        //   $HDR,time,lat,N/S,lon,E/W,fix,sats,hdop,alt,age,speed,heading,roll,pitch,yaw*cs
+        // Fields 12-14 (heading, roll, pitch) differ by flavour:
+        //   PANDA: heading = int(deg×10) or 65535 sentinel, roll = int(deg×10), pitch = float
+        //   PAOGI: heading = float (dual), roll = float (dual), pitch = int
+        var ci = CultureInfo.InvariantCulture;
+        bool paogi = MessageType == GpsMessageType.Paogi;
+
+        string time = DateTime.UtcNow.ToString("HHmmss.ff", ci);
         string lat = FormatLatitude(Latitude);
         string ns = Latitude >= 0 ? "N" : "S";
         string lon = FormatLongitude(Longitude);
         string ew = Longitude >= 0 ? "E" : "W";
 
         var sb = new StringBuilder();
-        sb.Append("$PANDA,");
+        sb.Append(paogi ? "$PAOGI," : "$PANDA,");
         sb.Append(time); sb.Append(',');
         sb.Append(lat); sb.Append(',');
         sb.Append(ns); sb.Append(',');
         sb.Append(lon); sb.Append(',');
         sb.Append(ew); sb.Append(',');
-        sb.Append(FixQuality.ToString(CultureInfo.InvariantCulture)); sb.Append(',');
-        sb.Append(Satellites.ToString(CultureInfo.InvariantCulture)); sb.Append(',');
-        sb.Append(Hdop.ToString("F1", CultureInfo.InvariantCulture)); sb.Append(',');
-        sb.Append(Altitude.ToString("F1", CultureInfo.InvariantCulture)); sb.Append(',');
-        sb.Append(DifferentialAge.ToString("F1", CultureInfo.InvariantCulture)); sb.Append(',');
-        sb.Append(SpeedKnots.ToString("F2", CultureInfo.InvariantCulture)); sb.Append(',');
-        // Fields 12-13: heading and roll as (int)(deg * 10), per Teensy firmware.
-        sb.Append(((int)Math.Round(HeadingDegrees * 10.0)).ToString(CultureInfo.InvariantCulture));
-        sb.Append(',');
-        sb.Append(((int)Math.Round(RollDegrees * 10.0)).ToString(CultureInfo.InvariantCulture));
-        sb.Append(',');
-        sb.Append(PitchDegrees.ToString("F2", CultureInfo.InvariantCulture)); sb.Append(',');
-        sb.Append(YawRateDegPerSec.ToString("F2", CultureInfo.InvariantCulture));
+        sb.Append(FixQuality.ToString(ci)); sb.Append(',');
+        sb.Append(Satellites.ToString(ci)); sb.Append(',');
+        sb.Append(Hdop.ToString("F1", ci)); sb.Append(',');
+        sb.Append(Altitude.ToString("F1", ci)); sb.Append(',');
+        sb.Append(DifferentialAge.ToString("F1", ci)); sb.Append(',');
+        sb.Append(SpeedKnots.ToString("F2", ci)); sb.Append(',');
 
-        // Calculate NMEA checksum (XOR of all chars between $ and *)
+        // Field 12: heading
+        if (paogi)
+            sb.Append(HeadingDegrees.ToString("F1", ci));
+        else
+            sb.Append(ImuValid ? ((int)Math.Round(HeadingDegrees * 10.0)).ToString(ci) : "65535");
+        sb.Append(',');
+
+        // Field 13: roll
+        if (paogi)
+            sb.Append(RollDegrees.ToString("F2", ci));
+        else
+            sb.Append(((int)Math.Round(RollDegrees * 10.0)).ToString(ci));
+        sb.Append(',');
+
+        // Field 14: pitch
+        sb.Append(paogi
+            ? ((int)Math.Round(PitchDegrees)).ToString(ci)
+            : PitchDegrees.ToString("F2", ci));
+        sb.Append(',');
+
+        // Field 15: yaw rate
+        sb.Append(YawRateDegPerSec.ToString("F2", ci));
+
+        // NMEA checksum (XOR of all chars between $ and *)
         string body = sb.ToString().Substring(1); // Skip the $
         byte checksum = 0;
         foreach (char c in body)
             checksum ^= (byte)c;
 
         sb.Append('*');
-        sb.Append(checksum.ToString("X2", CultureInfo.InvariantCulture));
+        sb.Append(checksum.ToString("X2", ci));
         sb.Append("\r\n");
 
         return sb.ToString();

--- a/Simulators/AgValoniaGPS.VehicleSimulator/Modules/VirtualMachineModule.cs
+++ b/Simulators/AgValoniaGPS.VehicleSimulator/Modules/VirtualMachineModule.cs
@@ -84,8 +84,19 @@ public class VirtualMachineModule : IDisposable
         }
     }
 
+    /// <summary>Taps for the sim's data panes (outgoing / incoming raw frames).</summary>
+    public Action<string>? OnSent;
+    public Action<string>? OnReceived;
+
+    private void Emit(byte[] packet)
+    {
+        OnSent?.Invoke(PgnProtocol.Describe(packet, packet.Length));
+        _udp.Send(packet, packet.Length, _hostEndpoint);
+    }
+
     private void ProcessPacket(byte[] data)
     {
+        OnReceived?.Invoke(PgnProtocol.Describe(data, data.Length));
         if (!PgnProtocol.IsValidPacket(data, data.Length))
             return;
 
@@ -131,7 +142,7 @@ public class VirtualMachineModule : IDisposable
     private void SendHello()
     {
         var packet = PgnProtocol.BuildHelloPacket(PgnProtocol.PGN_HELLO_MACHINE);
-        _udp.Send(packet, packet.Length, _hostEndpoint);
+        Emit(packet);
         SentHelloCount++;
     }
 

--- a/Simulators/AgValoniaGPS.VehicleSimulator/Modules/VirtualSteerModule.cs
+++ b/Simulators/AgValoniaGPS.VehicleSimulator/Modules/VirtualSteerModule.cs
@@ -208,7 +208,7 @@ public class VirtualSteerModule : IDisposable
         data[7] = PwmDisplay;
 
         var packet = PgnProtocol.BuildPacket(PgnProtocol.PGN_STEER_DATA, data);
-        _udp.Send(packet, packet.Length, _hostEndpoint);
+        Emit(packet);
         SentFeedbackCount++;
     }
 
@@ -220,7 +220,7 @@ public class VirtualSteerModule : IDisposable
         var data = new byte[8];
         data[0] = sensorValue;
         var packet = PgnProtocol.BuildPacket(PgnProtocol.PGN_SENSOR_DATA, data);
-        _udp.Send(packet, packet.Length, _hostEndpoint);
+        Emit(packet);
     }
 
     private async Task ReceiveLoop(CancellationToken ct)
@@ -237,8 +237,19 @@ public class VirtualSteerModule : IDisposable
         }
     }
 
+    /// <summary>Taps for the sim's data panes (outgoing / incoming raw frames).</summary>
+    public Action<string>? OnSent;
+    public Action<string>? OnReceived;
+
+    private void Emit(byte[] packet)
+    {
+        OnSent?.Invoke(PgnProtocol.Describe(packet, packet.Length));
+        _udp.Send(packet, packet.Length, _hostEndpoint);
+    }
+
     private void ProcessPacket(byte[] data)
     {
+        OnReceived?.Invoke(PgnProtocol.Describe(data, data.Length));
         if (!PgnProtocol.IsValidPacket(data, data.Length))
             return;
 
@@ -325,7 +336,7 @@ public class VirtualSteerModule : IDisposable
     private void SendHello()
     {
         var packet = PgnProtocol.BuildHelloPacket(PgnProtocol.PGN_HELLO_AUTOSTEER);
-        _udp.Send(packet, packet.Length, _hostEndpoint);
+        Emit(packet);
         SentHelloCount++;
     }
 

--- a/Simulators/AgValoniaGPS.VehicleSimulator/ViewModels/MainWindowViewModel.cs
+++ b/Simulators/AgValoniaGPS.VehicleSimulator/ViewModels/MainWindowViewModel.cs
@@ -7,6 +7,7 @@
 // (at your option) any later version.
 
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Windows.Input;
@@ -18,8 +19,12 @@ namespace AgValoniaGPS.VehicleSimulator.ViewModels;
 
 public enum DriveMode
 {
-    Bicycle,
-    Raw
+    // Physics sim: speed + wheel angle drive heading & position; IMU heading
+    // follows the vehicle, WAS follows the wheel angle.
+    Vehicle,
+    // Every sensor output is a decoupled slider (heading, roll, pitch, WAS) so
+    // each pipeline stage can be exercised in isolation.
+    Individual
 }
 
 public class MainWindowViewModel : INotifyPropertyChanged
@@ -44,7 +49,10 @@ public class MainWindowViewModel : INotifyPropertyChanged
     // Sensors
     private double _wasAngle; // degrees
     private double _maxPhysicalWheelAngle = 35.0; // degrees, ± clamp
-    private double _rollAngle; // degrees
+    private double _rollAngle; // degrees (IMU / dual-antenna roll)
+    private double _pitchAngle; // degrees (IMU pitch)
+    private bool _imuValid = true; // PANDA: false → 65535 no-IMU sentinel
+    private bool _isDualGps; // false = $PANDA (single), true = $PAOGI (dual)
     private int _fixQuality = 4; // RTK Fixed
     private int _satelliteCount = 12;
 
@@ -54,8 +62,19 @@ public class MainWindowViewModel : INotifyPropertyChanged
     private byte _pwmDisplay;
     private bool _steerSwitchOn;
     private bool _autoSteerEngaged;
-    private DriveMode _driveMode = DriveMode.Bicycle;
+    private DriveMode _driveMode = DriveMode.Vehicle;
     private string _statusText = "Stopped";
+
+    // Sent / Received data panes (newest line first). Freeze-frame via IsPaused.
+    private const int MaxLogLines = 200;
+    private readonly object _logSync = new();
+    private readonly List<string> _sentLines = new();
+    private readonly List<string> _receivedLines = new();
+    private string _sentLog = "";
+    private string _receivedLog = "";
+    private bool _sentDirty;
+    private bool _receivedDirty;
+    private bool _isPaused;
 
     // Applied module settings (mirrored from VirtualSteerModule for UI display)
     private byte _appliedKp;
@@ -164,8 +183,31 @@ public class MainWindowViewModel : INotifyPropertyChanged
     public double RollAngle
     {
         get => _rollAngle;
-        set { _rollAngle = Math.Clamp(value, -15, 15); OnPropertyChanged(); }
+        set { _rollAngle = Math.Clamp(value, -45, 45); OnPropertyChanged(); }
     }
+
+    public double PitchAngle
+    {
+        get => _pitchAngle;
+        set { _pitchAngle = Math.Clamp(value, -45, 45); OnPropertyChanged(); }
+    }
+
+    /// <summary>PANDA only: unchecking sends the 65535 no-IMU sentinel so the
+    /// host's ImuValid=false path is testable.</summary>
+    public bool ImuValid
+    {
+        get => _imuValid;
+        set { _imuValid = value; OnPropertyChanged(); }
+    }
+
+    /// <summary>false = single antenna ($PANDA), true = dual antenna ($PAOGI).</summary>
+    public bool IsDualGps
+    {
+        get => _isDualGps;
+        set { _isDualGps = value; OnPropertyChanged(); OnPropertyChanged(nameof(GpsMessageLabel)); }
+    }
+
+    public string GpsMessageLabel => _isDualGps ? "$PAOGI (dual)" : "$PANDA (single)";
 
     public int FixQuality
     {
@@ -223,6 +265,75 @@ public class MainWindowViewModel : INotifyPropertyChanged
     {
         get => _statusText;
         set { _statusText = value; OnPropertyChanged(); }
+    }
+
+    // === Sent / Received data panes ===
+
+    public string SentLog
+    {
+        get => _sentLog;
+        private set { _sentLog = value; OnPropertyChanged(); }
+    }
+
+    public string ReceivedLog
+    {
+        get => _receivedLog;
+        private set { _receivedLog = value; OnPropertyChanged(); }
+    }
+
+    /// <summary>Freeze-frame: when true, the data panes stop updating (the
+    /// simulation keeps running underneath) so a frame can be read / copied.</summary>
+    public bool IsPaused
+    {
+        get => _isPaused;
+        set { _isPaused = value; OnPropertyChanged(); OnPropertyChanged(nameof(PlayPauseLabel)); }
+    }
+
+    public string PlayPauseLabel => _isPaused ? "▶ Play" : "⏸ Pause";
+
+    private void AppendSent(string line) => Append(_sentLines, line, sent: true);
+    private void AppendReceived(string line) => Append(_receivedLines, line, sent: false);
+
+    // Taps fire on background receive/tick threads AND the UI thread (GPS send),
+    // possibly at a high host packet rate. Keep this O(1)-ish and do NO UI work
+    // here — just buffer the line and mark dirty. RefreshLogs (UI thread, 10 Hz)
+    // coalesces the redraw so the packet rate can't flood the dispatcher.
+    private void Append(List<string> buffer, string line, bool sent)
+    {
+        if (_isPaused) return; // freeze-frame: drop while paused
+        string stamped = $"{DateTime.Now:HH:mm:ss.fff}  {line}";
+        lock (_logSync)
+        {
+            buffer.Insert(0, stamped); // newest first
+            if (buffer.Count > MaxLogLines)
+                buffer.RemoveRange(MaxLogLines, buffer.Count - MaxLogLines);
+            if (sent) _sentDirty = true; else _receivedDirty = true;
+        }
+    }
+
+    /// <summary>UI-thread, called once per simulation tick (10 Hz). Rebuilds the
+    /// pane text only when new lines arrived, decoupling redraw from packet rate.</summary>
+    private void RefreshLogs()
+    {
+        string? sent = null, received = null;
+        lock (_logSync)
+        {
+            if (_sentDirty) { sent = string.Join(Environment.NewLine, _sentLines); _sentDirty = false; }
+            if (_receivedDirty) { received = string.Join(Environment.NewLine, _receivedLines); _receivedDirty = false; }
+        }
+        if (sent != null) SentLog = sent;
+        if (received != null) ReceivedLog = received;
+    }
+
+    private void ClearLogs()
+    {
+        lock (_logSync)
+        {
+            _sentLines.Clear();
+            _receivedLines.Clear();
+        }
+        SentLog = "";
+        ReceivedLog = "";
     }
 
     // === Applied-settings panel (read-only mirrors of VirtualSteerModule state) ===
@@ -343,9 +454,15 @@ public class MainWindowViewModel : INotifyPropertyChanged
     public ICommand WheelDownCommand { get; }
     public ICommand RollUpCommand { get; }
     public ICommand RollDownCommand { get; }
+    // Heading nudge wraps through 360/0 (the Heading setter is modulo 360), so the
+    // 360→0 boundary is testable — a slider can't cross a wrap.
+    public ICommand HeadingUpCommand { get; }
+    public ICommand HeadingDownCommand { get; }
     // Explicit "Save Position" — snapshots the CURRENT pose (works while running too,
     // so you can drive somewhere and save it as the new startup point).
     public ICommand SavePositionCommand { get; }
+    // Freeze-frame the sent/received data panes (sim keeps running).
+    public ICommand PlayPauseCommand { get; }
 
     private const double NudgeStep = 0.5;
 
@@ -367,7 +484,10 @@ public class MainWindowViewModel : INotifyPropertyChanged
         WheelDownCommand = new RelayCommand(() => WasAngle -= NudgeStep);
         RollUpCommand = new RelayCommand(() => RollAngle += NudgeStep);
         RollDownCommand = new RelayCommand(() => RollAngle -= NudgeStep);
+        HeadingUpCommand = new RelayCommand(() => Heading += NudgeStep);
+        HeadingDownCommand = new RelayCommand(() => Heading -= NudgeStep);
         SavePositionCommand = new RelayCommand(() => { SavePose(); StatusText = "Position saved"; });
+        PlayPauseCommand = new RelayCommand(() => IsPaused = !IsPaused);
     }
 
     private void ToggleRunning()
@@ -398,6 +518,9 @@ public class MainWindowViewModel : INotifyPropertyChanged
             _hub.Gps.FixQuality = FixQuality;
             _hub.Gps.Satellites = SatelliteCount;
             _hub.Gps.RollDegrees = RollAngle;
+            _hub.Gps.PitchDegrees = PitchAngle;
+            _hub.Gps.ImuValid = ImuValid;
+            _hub.Gps.MessageType = IsDualGps ? GpsMessageType.Paogi : GpsMessageType.Panda;
             _hub.Steer.ActualSteerAngleDeg = WasAngle;
             // Push the operator's mechanical-limit setting before Start
             // so the synthetic PWM loop clamps the simulated wheel angle
@@ -411,6 +534,14 @@ public class MainWindowViewModel : INotifyPropertyChanged
             // emit after Start (rather than the module defaults).
             _hub.Steer.VirtualCountsPerDegree = VirtualCountsPerDegree;
             _hub.Steer.VirtualWasOffset = VirtualWasOffset;
+
+            // Tap outgoing/incoming frames into the Sent / Received panes.
+            ClearLogs();
+            _hub.Gps.OnSent = AppendSent;
+            _hub.Steer.OnSent = AppendSent;
+            _hub.Steer.OnReceived = AppendReceived;
+            _hub.Machine.OnSent = AppendSent;
+            _hub.Machine.OnReceived = AppendReceived;
 
             _hub.Start();
 
@@ -461,7 +592,7 @@ public class MainWindowViewModel : INotifyPropertyChanged
         }
 
         const double dt = 0.1; // 10 Hz tick
-        if (DriveMode == DriveMode.Bicycle)
+        if (DriveMode == DriveMode.Vehicle)
         {
             _vehicle.SpeedKmh = Speed;
             _vehicle.SteerAngleDeg = WasAngle;
@@ -473,7 +604,7 @@ public class MainWindowViewModel : INotifyPropertyChanged
         }
         else
         {
-            // Raw mode: slider Heading is source of truth; just integrate position.
+            // Individual mode: slider Heading is source of truth; just integrate position.
             double speedMs = Speed / 3.6;
             double headingRad = Heading * Math.PI / 180.0;
             double dNorth = speedMs * Math.Cos(headingRad) * dt;
@@ -496,6 +627,9 @@ public class MainWindowViewModel : INotifyPropertyChanged
         _hub.Gps.FixQuality = FixQuality;
         _hub.Gps.Satellites = SatelliteCount;
         _hub.Gps.RollDegrees = RollAngle;
+        _hub.Gps.PitchDegrees = PitchAngle;
+        _hub.Gps.ImuValid = ImuValid;
+        _hub.Gps.MessageType = IsDualGps ? GpsMessageType.Paogi : GpsMessageType.Panda;
         // Only push slider → WAS when not engaged. When engaged the module's
         // PWM loop is the source of truth (we already pulled it into WasAngle
         // above), and pushing the slider value back would fight that loop.
@@ -527,6 +661,9 @@ public class MainWindowViewModel : INotifyPropertyChanged
         TruthRawCounts = _hub.Steer.TruthRawCounts;
 
         StatusText = $"Running, {_packetCount} packets sent";
+
+        // Coalesced redraw of the data panes (once per 10 Hz tick, not per packet).
+        RefreshLogs();
     }
 
     public event PropertyChangedEventHandler? PropertyChanged;

--- a/Simulators/AgValoniaGPS.VehicleSimulator/Views/MainWindow.axaml
+++ b/Simulators/AgValoniaGPS.VehicleSimulator/Views/MainWindow.axaml
@@ -4,14 +4,14 @@
         x:Class="AgValoniaGPS.VehicleSimulator.Views.MainWindow"
         x:DataType="vm:MainWindowViewModel"
         Title="AgValoniaGPS Vehicle Simulator"
-        Width="1024" Height="540"
+        Width="1280" Height="760"
         MinWidth="400" MinHeight="200">
 
     <Design.DataContext>
         <vm:MainWindowViewModel />
     </Design.DataContext>
 
-    <Grid Margin="16" RowDefinitions="Auto,*,Auto">
+    <Grid Margin="16" RowDefinitions="Auto,*,Auto,Auto">
 
         <!-- Header -->
         <TextBlock Grid.Row="0" Text="Vehicle Simulator"
@@ -20,14 +20,15 @@
 
         <!-- Four-column semantic layout, matching the real-hardware mental model:
                  [Bicycle Model] = physics inputs (operator drives the vehicle)
-                 [GPS]           = position + IMU sensor outputs
-                 [WAS]           = simulated WAS hardware truth + host's applied calibration
+                 [GPS]           = position + message-type (PANDA/PAOGI)
+                 [IMU]           = heading / pitch / roll sensor outputs
+                 [WAS]           = injected WAS angle + hardware truth + host's applied calibration
                  [Module Status] = outgoing PGN 253 state + switch toggles
              Stays scrollable when the window is narrower than the natural width. -->
         <ScrollViewer Grid.Row="1" Margin="0,0,0,12"
                       HorizontalScrollBarVisibility="Auto"
                       VerticalScrollBarVisibility="Auto">
-        <Grid ColumnDefinitions="*,*,*,*" MinWidth="900">
+        <Grid ColumnDefinitions="*,*,*,*,*" MinWidth="1180">
 
             <!-- Column 1: Bicycle Model (physics inputs) -->
             <Border Grid.Column="0" Margin="0,0,6,0" Padding="12"
@@ -38,8 +39,8 @@
 
                     <TextBlock Text="Drive Mode" />
                     <ComboBox SelectedItem="{Binding DriveMode}" HorizontalAlignment="Stretch">
-                        <vm:DriveMode>Bicycle</vm:DriveMode>
-                        <vm:DriveMode>Raw</vm:DriveMode>
+                        <vm:DriveMode>Vehicle</vm:DriveMode>
+                        <vm:DriveMode>Individual</vm:DriveMode>
                     </ComboBox>
 
                     <Grid ColumnDefinitions="*,Auto,Auto,Auto">
@@ -70,14 +71,6 @@
                     <Slider Minimum="-45" Maximum="45" Value="{Binding WasAngle}"
                             TickFrequency="1" IsSnapToTickEnabled="False"
                             ToolTip.Tip="Physical wheel angle. The simulated WAS reads this and applies the virtual hardware calibration before PGN 253 reports it." />
-
-                    <!-- Heading is only an operator input in Raw mode; in Bicycle
-                         mode it's an output of the kinematic integrator. Kept
-                         in this column because Raw mode needs operator control. -->
-                    <TextBlock Text="{Binding Heading, StringFormat='Heading: {0:F1} deg'}" />
-                    <Slider Minimum="0" Maximum="359.9" Value="{Binding Heading}"
-                            TickFrequency="1" IsSnapToTickEnabled="False"
-                            ToolTip.Tip="Raw mode: operator-controlled heading. Bicycle mode: computed from speed × wheel angle." />
                 </StackPanel>
             </Border>
 
@@ -87,6 +80,13 @@
                     BorderThickness="1" CornerRadius="4">
                 <StackPanel Spacing="8">
                     <TextBlock Text="GPS" FontWeight="SemiBold" FontSize="14" />
+
+                    <!-- Message type: $PANDA (single antenna + IMU) vs $PAOGI
+                         (dual antenna). Controls how fields 12-13 are encoded. -->
+                    <CheckBox Content="Dual antenna ($PAOGI)" IsChecked="{Binding IsDualGps}"
+                              ToolTip.Tip="Unchecked = $PANDA (single + IMU, heading/roll as int×10). Checked = $PAOGI (dual antenna, heading/roll as floats)." />
+                    <TextBlock Text="{Binding GpsMessageLabel, StringFormat='Sending: {0}'}" FontSize="12"
+                               Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}" />
 
                     <TextBlock Text="{Binding Latitude, StringFormat='Latitude: {0:F8}'}" />
                     <NumericUpDown Value="{Binding Latitude}" Increment="0.0001"
@@ -114,25 +114,70 @@
                         <ComboBoxItem Content="5 - RTK Float" />
                     </ComboBox>
 
-                    <!-- Roll lives here because it's the IMU's sensor output,
-                         carried by $PANDA alongside the GPS-side data. -->
-                    <Grid ColumnDefinitions="*,Auto,Auto,Auto">
-                        <TextBlock Grid.Column="0" Text="{Binding RollAngle, StringFormat='Roll (IMU): {0:F1} deg'}" VerticalAlignment="Center" />
-                        <Button Grid.Column="1" Content="−" Padding="10,2" Command="{Binding RollDownCommand}" ToolTip.Tip="−0.5°" />
-                        <Button Grid.Column="2" Content="+" Padding="10,2" Margin="4,0" Command="{Binding RollUpCommand}" ToolTip.Tip="+0.5°" />
-                        <Button Grid.Column="3" Content="0" Padding="14,2" Command="{Binding ZeroRollCommand}" ToolTip.Tip="Zero roll" />
-                    </Grid>
-                    <Slider Minimum="-15" Maximum="15" Value="{Binding RollAngle}"
-                            TickFrequency="0.5" IsSnapToTickEnabled="False" />
                 </StackPanel>
             </Border>
 
-            <!-- Column 3: WAS (simulated hardware truth + host's applied calibration) -->
+            <!-- Column 3: IMU (heading / pitch / roll sensor outputs) -->
             <Border Grid.Column="2" Margin="3,0,3,0" Padding="12"
                     BorderBrush="{DynamicResource SystemControlForegroundBaseMediumBrush}"
                     BorderThickness="1" CornerRadius="4">
                 <StackPanel Spacing="8">
+                    <TextBlock Text="IMU" FontWeight="SemiBold" FontSize="14" />
+
+                    <!-- PANDA only: unchecking sends the 65535 no-IMU sentinel so
+                         the host's ImuValid=false branch can be exercised. -->
+                    <CheckBox Content="IMU Valid" IsChecked="{Binding ImuValid}"
+                              ToolTip.Tip="PANDA only: unchecked sends 65535 (no-IMU sentinel) in the heading field." />
+
+                    <!-- Heading: in Vehicle mode this is the physics-computed
+                         heading (display); in Individual mode it's the live
+                         slider that drives the heading on the wire. -->
+                    <Grid ColumnDefinitions="*,Auto,Auto">
+                        <TextBlock Grid.Column="0" Text="{Binding Heading, StringFormat='Heading: {0:F1} deg'}" VerticalAlignment="Center" />
+                        <Button Grid.Column="1" Content="−" Padding="10,2" Command="{Binding HeadingDownCommand}" ToolTip.Tip="−0.5° (wraps through 0/360)" />
+                        <Button Grid.Column="2" Content="+" Padding="10,2" Margin="4,0" Command="{Binding HeadingUpCommand}" ToolTip.Tip="+0.5° (wraps through 360/0)" />
+                    </Grid>
+                    <Slider Minimum="0" Maximum="359.9" Value="{Binding Heading}"
+                            TickFrequency="1" IsSnapToTickEnabled="False"
+                            ToolTip.Tip="Individual mode: operator-controlled heading. Vehicle mode: computed from speed × wheel angle. Use −/+ to step across the 360/0 wrap." />
+
+                    <TextBlock Text="{Binding PitchAngle, StringFormat='Pitch: {0:F1} deg'}" />
+                    <Slider Minimum="-45" Maximum="45" Value="{Binding PitchAngle}"
+                            TickFrequency="1" IsSnapToTickEnabled="False" />
+
+                    <Grid ColumnDefinitions="*,Auto,Auto,Auto">
+                        <TextBlock Grid.Column="0" Text="{Binding RollAngle, StringFormat='Roll: {0:F1} deg'}" VerticalAlignment="Center" />
+                        <Button Grid.Column="1" Content="−" Padding="10,2" Command="{Binding RollDownCommand}" ToolTip.Tip="−0.5°" />
+                        <Button Grid.Column="2" Content="+" Padding="10,2" Margin="4,0" Command="{Binding RollUpCommand}" ToolTip.Tip="+0.5°" />
+                        <Button Grid.Column="3" Content="0" Padding="14,2" Command="{Binding ZeroRollCommand}" ToolTip.Tip="Zero roll" />
+                    </Grid>
+                    <Slider Minimum="-45" Maximum="45" Value="{Binding RollAngle}"
+                            TickFrequency="0.5" IsSnapToTickEnabled="False"
+                            ToolTip.Tip="IMU roll (PANDA) / dual-antenna roll (PAOGI), field 13 on the wire." />
+                </StackPanel>
+            </Border>
+
+            <!-- Column 4: WAS (injected angle + simulated hardware truth + host's applied calibration) -->
+            <Border Grid.Column="3" Margin="3,0,3,0" Padding="12"
+                    BorderBrush="{DynamicResource SystemControlForegroundBaseMediumBrush}"
+                    BorderThickness="1" CornerRadius="4">
+                <StackPanel Spacing="8">
                     <TextBlock Text="WAS" FontWeight="SemiBold" FontSize="14" />
+
+                    <!-- Injected WAS angle. Vehicle mode: mirrors the wheel angle
+                         that drives the physics. Individual mode: the WAS reported
+                         to the host directly (decoupled from any vehicle motion). -->
+                    <Grid ColumnDefinitions="*,Auto,Auto,Auto">
+                        <TextBlock Grid.Column="0" Text="{Binding WasAngle, StringFormat='WAS Angle: {0:F1} deg'}" VerticalAlignment="Center" />
+                        <Button Grid.Column="1" Content="−" Padding="10,2" Command="{Binding WheelDownCommand}" ToolTip.Tip="−0.5°" />
+                        <Button Grid.Column="2" Content="+" Padding="10,2" Margin="4,0" Command="{Binding WheelUpCommand}" ToolTip.Tip="+0.5°" />
+                        <Button Grid.Column="3" Content="&gt;0&lt;" Padding="10,2" Command="{Binding CenterWheelCommand}" ToolTip.Tip="Center (0°)" />
+                    </Grid>
+                    <Slider Minimum="-45" Maximum="45" Value="{Binding WasAngle}"
+                            TickFrequency="1" IsSnapToTickEnabled="False"
+                            ToolTip.Tip="Reported WAS angle (PGN 253). Individual mode injects this directly; Vehicle mode drives it from the wheel angle." />
+
+                    <Separator Margin="0,4" />
 
                     <!-- Ground-truth hardware values: the *real* CPD and offset
                          of the simulated WAS sensor. Operator-adjustable so the
@@ -181,8 +226,8 @@
                 </StackPanel>
             </Border>
 
-            <!-- Column 4: Module Status (outgoing PGN 253 + switch toggles) -->
-            <Border Grid.Column="3" Margin="6,0,0,0" Padding="12"
+            <!-- Column 5: Module Status (outgoing PGN 253 + switch toggles) -->
+            <Border Grid.Column="4" Margin="6,0,0,0" Padding="12"
                     BorderBrush="{DynamicResource SystemControlForegroundBaseMediumBrush}"
                     BorderThickness="1" CornerRadius="4">
                 <StackPanel Spacing="8">
@@ -228,8 +273,36 @@
         </Grid>
         </ScrollViewer>
 
+        <!-- Sent / Received data panes with freeze-frame. Read-only TextBoxes →
+             native text selection + Ctrl-C. Newest line on top. -->
+        <Grid Grid.Row="2" RowDefinitions="Auto,170" Margin="0,0,0,8">
+            <Grid Grid.Row="0" ColumnDefinitions="*,Auto,*" Margin="0,0,0,4">
+                <TextBlock Grid.Column="0" Text="Sent  →  host" FontWeight="SemiBold"
+                           VerticalAlignment="Center" />
+                <Button Grid.Column="1" Content="{Binding PlayPauseLabel}"
+                        Command="{Binding PlayPauseCommand}" Padding="14,4"
+                        ToolTip.Tip="Freeze / resume the data panes (the simulation keeps running)" />
+                <TextBlock Grid.Column="2" Text="host  →  Received" FontWeight="SemiBold"
+                           HorizontalAlignment="Right" VerticalAlignment="Center" />
+            </Grid>
+            <Grid Grid.Row="1" ColumnDefinitions="*,*">
+                <TextBox Grid.Column="0" Text="{Binding SentLog, Mode=OneWay}"
+                         IsReadOnly="True" AcceptsReturn="True" TextWrapping="NoWrap"
+                         FontFamily="Cascadia Mono,Consolas,Menlo,monospace" FontSize="11"
+                         VerticalContentAlignment="Top" Margin="0,0,3,0"
+                         ScrollViewer.HorizontalScrollBarVisibility="Auto"
+                         ScrollViewer.VerticalScrollBarVisibility="Auto" />
+                <TextBox Grid.Column="1" Text="{Binding ReceivedLog, Mode=OneWay}"
+                         IsReadOnly="True" AcceptsReturn="True" TextWrapping="NoWrap"
+                         FontFamily="Cascadia Mono,Consolas,Menlo,monospace" FontSize="11"
+                         VerticalContentAlignment="Top" Margin="3,0,0,0"
+                         ScrollViewer.HorizontalScrollBarVisibility="Auto"
+                         ScrollViewer.VerticalScrollBarVisibility="Auto" />
+            </Grid>
+        </Grid>
+
         <!-- Bottom bar -->
-        <Grid Grid.Row="2" ColumnDefinitions="Auto,*">
+        <Grid Grid.Row="3" ColumnDefinitions="Auto,*">
             <Button Grid.Column="0" Command="{Binding StartStopCommand}"
                     Content="{Binding StartStopLabel}"
                     MinWidth="100" HorizontalContentAlignment="Center"

--- a/Tests/AgValoniaGPS.Services.Tests/Issue478HeadingRollTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/Issue478HeadingRollTests.cs
@@ -1,0 +1,234 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2026 AgValoniaGPS Contributors
+//
+// Licensed under GNU GPL v3. See LICENSE.md.
+
+using System;
+using System.Net;
+using System.Net.Sockets;
+using AgValoniaGPS.IntegrationTests.VirtualModules;
+using AgValoniaGPS.Models;
+using AgValoniaGPS.Models.Base;
+using AgValoniaGPS.Models.Configuration;
+using AgValoniaGPS.Models.State;
+using AgValoniaGPS.Services;
+using AgValoniaGPS.Services.AutoSteer;
+using AgValoniaGPS.Services.Coverage;
+using AgValoniaGPS.Services.Gps;
+using AgValoniaGPS.Services.Interfaces;
+using AgValoniaGPS.Services.Pipeline;
+using AgValoniaGPS.Services.Section;
+using AgValoniaGPS.Services.Tool;
+using AgValoniaGPS.Services.Track;
+using AgValoniaGPS.Services.YouTurn;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace AgValoniaGPS.Services.Tests;
+
+/// <summary>
+/// Repro harness for issue #478 (heading sticks at the 360/0 wrap; roll has a
+/// ±10° dead-zone / one-sided / invert-no-effect). Drives REAL $PANDA bytes
+/// from the Vehicle Simulator through the production zero-copy parser
+/// (<see cref="NmeaParserServiceFast.ParseIntoState"/>) and asserts the parsed
+/// VehicleState. This isolates the FIRST hop (parse) from the downstream
+/// consumer/mapping layer.
+/// </summary>
+[TestFixture]
+public class Issue478HeadingRollTests
+{
+    /// <summary>Capture the raw $PANDA bytes the simulator emits for a given heading/roll.</summary>
+    private static byte[] CapturePanda(double headingDeg, double rollDeg)
+    {
+        using var listener = new UdpClient(0);
+        int port = ((IPEndPoint)listener.Client.LocalEndPoint!).Port;
+
+        using var gps = new VirtualGpsReceiver(targetPort: port);
+        gps.Latitude = 43.7128;
+        gps.Longitude = -74.0060;
+        gps.FixQuality = 4;
+        gps.Satellites = 14;
+        gps.SpeedKnots = 5.0;
+        gps.HeadingDegrees = headingDeg;
+        gps.RollDegrees = rollDeg;
+
+        gps.SendOnce();
+
+        listener.Client.ReceiveTimeout = 2000;
+        IPEndPoint? remote = null;
+        return listener.Receive(ref remote);
+    }
+
+    private static AgValoniaGPS.Models.VehicleState ParsePanda(double headingDeg, double rollDeg)
+    {
+        var bytes = CapturePanda(headingDeg, rollDeg);
+        var state = new AgValoniaGPS.Models.VehicleState();
+        var config = new ConfigurationStore(); // IsRollInvert=false, RollZero=0
+        NmeaParserServiceFast.ParseIntoState(bytes, ref state, config);
+        return state;
+    }
+
+    // ── ROLL: both signs and small magnitudes should round-trip ──────────────
+    [TestCase(15.0)]
+    [TestCase(-15.0)]
+    [TestCase(3.0)]
+    [TestCase(-3.0)]
+    [TestCase(0.5)]
+    [TestCase(-0.5)]
+    public void Roll_RoundTripsBothSigns(double rollDeg)
+    {
+        var state = ParsePanda(headingDeg: 90.0, rollDeg: rollDeg);
+
+        Assert.That(state.Roll, Is.EqualTo(rollDeg).Within(0.06),
+            $"Parsed roll should equal sent roll ({rollDeg}°). Dead-zone/one-sided => bug here.");
+    }
+
+    [Test]
+    public void Roll_InvertFlipsSign()
+    {
+        var bytes = CapturePanda(headingDeg: 90.0, rollDeg: 12.0);
+
+        var normal = new AgValoniaGPS.Models.VehicleState();
+        var cfgNormal = new ConfigurationStore();
+        NmeaParserServiceFast.ParseIntoState(bytes, ref normal, cfgNormal);
+
+        var inverted = new AgValoniaGPS.Models.VehicleState();
+        var cfgInvert = new ConfigurationStore();
+        cfgInvert.Ahrs.IsRollInvert = true;
+        NmeaParserServiceFast.ParseIntoState(bytes, ref inverted, cfgInvert);
+
+        Assert.That(inverted.Roll, Is.EqualTo(-normal.Roll).Within(0.06),
+            "IsRollInvert should flip the sign of parsed roll.");
+    }
+
+    // ── HEADING: must track continuously across the 360/0 wrap ───────────────
+    [TestCase(350.0)]
+    [TestCase(359.0)]
+    [TestCase(0.0)]
+    [TestCase(1.0)]
+    [TestCase(10.0)]
+    public void Heading_TracksAcrossWrap(double headingDeg)
+    {
+        var state = ParsePanda(headingDeg: headingDeg, rollDeg: 0.0);
+
+        Assert.That(state.Heading, Is.EqualTo(headingDeg).Within(0.06),
+            $"Parsed heading should equal sent heading ({headingDeg}°), including near the 360/0 wrap.");
+    }
+}
+
+/// <summary>
+/// End-to-end repro for #478: feed a GpsData (exactly what
+/// AutoSteerService.PublishGpsData emits — ImuRoll = _state.Roll, ImuValid set)
+/// through the REAL GpsPipelineService + real GpsHeadingFusionService and read
+/// the published GpsCycleResult (what the gauge/display binds to).
+/// </summary>
+[TestFixture]
+[NonParallelizable] // ConfigurationStore is a singleton.
+public class Issue478PipelineTests
+{
+    private GpsService _gps = null!;
+    private GpsPipelineService _pipeline = null!;
+    private GpsCycleResult? _lastResult;
+
+    [SetUp]
+    public void SetUp()
+    {
+        ConfigurationStore.SetInstance(new ConfigurationStore());
+        var config = ConfigurationStore.Instance;
+        config.Vehicle.AntennaPivot = 0;
+        config.Vehicle.AntennaOffset = 0;
+        config.Vehicle.AntennaHeight = 0;
+        config.Tool.Width = 6;
+        config.NumSections = 1;
+        config.Tool.SetSectionWidth(0, 600);
+
+        var appState = new ApplicationState();
+        appState.Field.LocalPlane = new LocalPlane(
+            new Wgs84(43.7128, -74.006), new SharedFieldProperties());
+
+        _gps = new GpsService();
+        _gps.Start();
+
+        var toolPosition = new ToolPositionService(config);
+        var coverage = new CoverageMapService(config);
+        var sectionControl = new SectionControlService(toolPosition, coverage, appState, config);
+        var autoSteer = new AutoSteerService(new TrackGuidanceService(),
+            Substitute.For<IUdpCommunicationService>(), _gps, appState, config);
+
+        // REAL heading fusion — this is what we're testing for the wrap.
+        var headingFusion = new GpsHeadingFusionService(config);
+
+        _pipeline = new GpsPipelineService(
+            _gps, toolPosition, new TrackGuidanceService(),
+            sectionControl, coverage, autoSteer,
+            new YouTurnGuidanceService(),
+            new YouTurnStateMachine(
+                new YouTurnCreationService(NullLogger<YouTurnCreationService>.Instance,
+                    Substitute.For<AgValoniaGPS.Services.Geometry.IPolygonOffsetService>(), config),
+                new YouTurnPathingService(NullLogger<YouTurnPathingService>.Instance, config),
+                NullLogger<YouTurnStateMachine>.Instance, config),
+            Substitute.For<IAudioService>(),
+            new PipelineIntents(),
+            headingFusion,
+            NullLogger<GpsPipelineService>.Instance, appState,
+            config,
+            new PositionEstimator());
+
+        _pipeline.SynchronousMode = true;
+        _pipeline.CycleCompleted += r => _lastResult = r;
+        _pipeline.Start();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _pipeline.Stop();
+        _gps.Stop();
+    }
+
+    private static GpsData Fix(double heading, double roll, double speed = 5.0, bool imuValid = true)
+        => new()
+        {
+            CurrentPosition = new Position
+            {
+                Latitude = 43.7128, Longitude = -74.006,
+                Heading = heading, Speed = speed,
+            },
+            FixQuality = 4,
+            ImuValid = imuValid,
+            ImuHeading = heading,
+            ImuRoll = roll,
+            IsValid = true,
+        };
+
+    // ── ROLL: the value the gauge binds to (GpsCycleResult.RollDegrees) ──────
+    [TestCase(15.0)]
+    [TestCase(-15.0)]
+    [TestCase(3.0)]
+    [TestCase(-3.0)]
+    public void Pipeline_RollDegrees_RoundTripsBothSigns(double rollDeg)
+    {
+        _gps.UpdateGpsData(Fix(heading: 90, roll: rollDeg));
+
+        Assert.That(_lastResult, Is.Not.Null);
+        Assert.That(_lastResult!.RollDegrees, Is.EqualTo(rollDeg).Within(0.06),
+            $"Published RollDegrees should equal input roll ({rollDeg}°) for both signs.");
+    }
+
+    // ── HEADING: published heading must track continuously across 360/0 ──────
+    [TestCase(350.0)]
+    [TestCase(359.0)]
+    [TestCase(0.0)]
+    [TestCase(1.0)]
+    [TestCase(10.0)]
+    public void Pipeline_Heading_TracksAcrossWrap(double headingDeg)
+    {
+        // Low speed so fix-to-fix doesn't override the IMU heading.
+        _gps.UpdateGpsData(Fix(heading: headingDeg, roll: 0, speed: 0.0));
+
+        Assert.That(_lastResult, Is.Not.Null);
+        double h = ((_lastResult!.Heading % 360) + 360) % 360;
+        Assert.That(h, Is.EqualTo(headingDeg).Within(0.5),
+            $"Published heading should equal input heading ({headingDeg}°) across the wrap.");
+    }
+}


### PR DESCRIPTION
## Vehicle Simulator expansion
- **GPS message type** toggle: Single (`$PANDA`) / Dual (`$PAOGI`), matching the AiO firmware wire format (PAOGI heading/roll as floats; PANDA as int×10 with the 65535 no-IMU sentinel).
- **IMU section**: Heading / Pitch / Roll sliders + an `IMU Valid` toggle (unchecked → 65535 sentinel).
- **Heading nudge buttons** that wrap through 360/0 — a slider can't cross a wrap, which made the #478 boundary untestable.
- **WAS** angle injection slider.
- Drive mode `Bicycle`/`Raw` → **`Vehicle`/`Individual`** (decoupled per-output control for isolating one pipeline stage at a time).
- **Sent / Received data panes** (read-only, Ctrl-C copyable) with **Play/Pause** freeze-frame. Redraw is **coalesced to the 10 Hz tick** so a high host packet rate can't flood the UI thread.

## Tests
`Issue478HeadingRollTests` — simulator-driven, real `$PANDA` bytes through the production parser and the full `GpsPipelineService`: roll round-trips both signs (incl. ±0.5°), IsRollInvert flips sign, heading tracks across the 360/0 wrap.

Context: these came out of the #478 investigation. Root cause turned out to be **two GPS sources feeding the pipeline at once** (internal sim + external NMEA) — the expanded VSim is what made that obvious. The mutual-exclusion guard is a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)