### PR TITLE
Gate internal sim against a live GPS source (#478 dual-source fix)

### DIFF
--- a/Shared/AgValoniaGPS.Services/AutoSteer/AutoSteerService.cs
+++ b/Shared/AgValoniaGPS.Services/AutoSteer/AutoSteerService.cs
@@ -458,6 +458,11 @@ public class AutoSteerService : IAutoSteerService
                 return;
             }
 
+            // Real GPS fix parsed from inbound NMEA — mark the live-GPS gate so the
+            // internal simulator stays mutually exclusive with a live source. The
+            // sim feeds via GpsService.UpdateGpsData and never reaches this path.
+            _gpsService.MarkRealGpsParsed();
+
             // Publish the parsed fix to GpsService. This is the sole event the
             // cycle worker listens to; everything else runs there.
             PublishGpsData();

--- a/Shared/AgValoniaGPS.Services/GpsService.cs
+++ b/Shared/AgValoniaGPS.Services/GpsService.cs
@@ -38,6 +38,13 @@ public class GpsService : IGpsService
     private const int GPS_TIMEOUT_MS = 300; // 10Hz data = 100ms cycle, allow 300ms
     private const int IMU_TIMEOUT_MS = 300; // 10Hz data = 100ms cycle, allow 300ms
 
+    // Real-GPS-live gate: stamped ONLY on a successful parse of inbound NMEA
+    // (AutoSteerService.ProcessGpsBuffer). The internal simulator feeds via
+    // UpdateGpsData and never parses, so this signal is real-source-only — used
+    // to keep the sim and a live GPS source mutually exclusive.
+    private DateTime _lastRealGpsParseTime = DateTime.MinValue;
+    private const int GPS_LIVE_TIMEOUT_MS = 2000; // wider than GPS_TIMEOUT_MS so the gate doesn't flap on a dropped packet
+
     public void Start()
     {
         IsConnected = true;
@@ -47,6 +54,19 @@ public class GpsService : IGpsService
     {
         IsConnected = false;
     }
+
+    /// <summary>
+    /// Mark that a real GPS fix was just parsed from inbound NMEA (real source
+    /// only — the simulator never reaches this path). Drives <see cref="IsGpsLive"/>.
+    /// </summary>
+    public void MarkRealGpsParsed() => _lastRealGpsParseTime = Clock.Current.Now;
+
+    /// <summary>
+    /// True when real (parsed-from-NMEA) GPS data has arrived recently. Used to
+    /// gate the internal simulator so the two can't drive the pipeline at once.
+    /// </summary>
+    public bool IsGpsLive =>
+        (Clock.Current.Now - _lastRealGpsParseTime).TotalMilliseconds < GPS_LIVE_TIMEOUT_MS;
 
     public void ProcessNmeaSentence(string sentence)
     {

--- a/Shared/AgValoniaGPS.Services/Interfaces/IGpsService.cs
+++ b/Shared/AgValoniaGPS.Services/Interfaces/IGpsService.cs
@@ -66,6 +66,19 @@ public interface IGpsService
     void MarkGpsReceived();
 
     /// <summary>
+    /// Mark that a real GPS fix was parsed from inbound NMEA. Stamped ONLY on the
+    /// real receive/parse path — the internal simulator feeds via UpdateGpsData
+    /// and never parses, so this is a real-source-only signal. Drives <see cref="IsGpsLive"/>.
+    /// </summary>
+    void MarkRealGpsParsed();
+
+    /// <summary>
+    /// True when real (parsed-from-NMEA) GPS data has arrived recently. Used to
+    /// keep the internal simulator and a live GPS source mutually exclusive.
+    /// </summary>
+    bool IsGpsLive { get; }
+
+    /// <summary>
     /// Update IMU data timestamp (called when IMU data received)
     /// </summary>
     void UpdateImuData();

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.Simulator.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.Simulator.cs
@@ -47,6 +47,15 @@ public partial class MainViewModel
 
     private void OnSimulatorTick(object? sender, EventArgs e)
     {
+        // Mutual exclusion with a live GPS source: if real (parsed) GPS data
+        // started arriving while the sim is running, stop the sim. The internal
+        // sim and a live source must not drive the pipeline at once (see #478).
+        if (_gpsService.IsGpsLive)
+        {
+            IsSimulatorEnabled = false; // stops the timer + emits a final stationary frame
+            return;
+        }
+
         // Call simulator Tick with current steer angle
         _simulatorService.Tick(SimulatorSteerAngle);
     }
@@ -125,6 +134,14 @@ public partial class MainViewModel
         get => _isSimulatorEnabled;
         set
         {
+            // Mutual exclusion with a live GPS source: refuse to enable the sim
+            // while real (parsed) GPS data is arriving over UDP (see #478).
+            if (value && !_isSimulatorEnabled && _gpsService.IsGpsLive)
+            {
+                OnPropertyChanged(); // snap the bound toggle back to off
+                return;
+            }
+
             // Hardware parity stop: when DISABLING, emit one final stationary
             // frame BEFORE flipping the flag. OnSimulatorGpsDataUpdated guards
             // on !_isSimulatorEnabled and drops events once the flag flips,


### PR DESCRIPTION
Fixes the #478 root cause: the internal simulator and a real GPS source feeding UDP could both drive the pipeline at once, interleaving frame-by-frame — roll read ~0 and heading fought at the 360/0 wrap.

## Change
- **`GpsService.MarkRealGpsParsed()` + `IsGpsLive`** — real-source-only (stamped only on a successful inbound NMEA parse; the sim feeds via `UpdateGpsData` and never parses, so the parser is the discriminator). 2 s window so it doesn't flap on a dropped packet.
- **`AutoSteerService.ProcessGpsBuffer`** marks the gate on each successful real parse.
- **`MainViewModel`**: **block-start** (can't enable the sim while GPS is live) + **auto-stop** (sim turns off if real GPS goes live mid-run).

Mutual exclusion lives in the domain (set on the receive/parse path, evaluated against a timestamp); the only UI work is reverting the toggle — no UI-thread polling. The gate is **shared**, so it applies to **both legacy and web UIs** (verified on web: GPS-via-UDP blocks the sim from starting, and kicks it off if started).

No popup: a native dialog wouldn't surface in the web UI anyway, and the toggle snapping back / sim stopping is sufficient feedback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)