### PR TITLE
Audio: one self-releasing player per sound so effects overlap

### DIFF
--- a/Platforms/AgOpenWeb.Android/Services/AudioService.cs
+++ b/Platforms/AgOpenWeb.Android/Services/AudioService.cs
@@ -14,24 +14,30 @@ namespace AgOpenWeb.Android.Services;
 /// </summary>
 public class AudioService : AudioServiceBase
 {
-    private MediaPlayer? _mediaPlayer;
-
     public AudioService(AgOpenWeb.Models.Configuration.ConfigurationStore configStore)
         : base(configStore) { }
 
     protected override void PlayFile(string filePath)
     {
-        _mediaPlayer?.Release();
-        _mediaPlayer = null;
-
-        _mediaPlayer = new MediaPlayer();
-        _mediaPlayer.SetDataSource(filePath);
-        _mediaPlayer.Prepare();
-        _mediaPlayer.Start();
-        _mediaPlayer.Completion += (s, e) =>
+        // One self-releasing player per sound. A single shared MediaPlayer cut sounds off:
+        // section on/off can fire several times in quick succession, and releasing the still-
+        // playing instance before starting the next dropped them inconsistently. Each play now
+        // gets its own player so they overlap, and PrepareAsync keeps the host control loop
+        // (which raises these) from blocking on prepare. Callbacks arrive on the main looper
+        // (the host-loop thread has none), so cleanup is safe.
+        var player = new MediaPlayer();
+        void Release() { try { player.Release(); } catch { /* already gone */ } }
+        player.Completion += (_, _) => Release();
+        player.Error += (_, e) => { e.Handled = true; Release(); };
+        player.Prepared += (_, _) => { try { player.Start(); } catch { Release(); } };
+        try
         {
-            _mediaPlayer?.Release();
-            _mediaPlayer = null;
-        };
+            player.SetDataSource(filePath);
+            player.PrepareAsync();
+        }
+        catch
+        {
+            Release();
+        }
     }
 }

--- a/Platforms/AgOpenWeb.iOS/Services/AudioService.cs
+++ b/Platforms/AgOpenWeb.iOS/Services/AudioService.cs
@@ -15,26 +15,33 @@ namespace AgOpenWeb.iOS.Services;
 /// </summary>
 public class AudioService : AudioServiceBase
 {
-    private AVAudioPlayer? _currentPlayer;
+    // Players kept alive until they finish (else GC stops the sound mid-play). One per play so
+    // sounds overlap: a single shared player cut sounds off — section on/off can fire several
+    // times in quick succession, and disposing the still-playing instance dropped them.
+    private readonly System.Collections.Generic.List<AVAudioPlayer> _active = new();
 
     public AudioService(AgOpenWeb.Models.Configuration.ConfigurationStore configStore)
         : base(configStore) { }
 
     protected override void PlayFile(string filePath)
     {
-        _currentPlayer?.Dispose();
-        _currentPlayer = null;
-
         var url = NSUrl.FromFilename(filePath);
         if (url == null) return;
 
-        _currentPlayer = AVAudioPlayer.FromUrl(url, out var error);
-        if (error != null)
+        var player = AVAudioPlayer.FromUrl(url, out var error);
+        if (error != null || player == null)
         {
-            System.Diagnostics.Debug.WriteLine($"[Audio] iOS AVAudioPlayer error: {error.LocalizedDescription}");
+            System.Diagnostics.Debug.WriteLine($"[Audio] iOS AVAudioPlayer error: {error?.LocalizedDescription}");
+            player?.Dispose();
             return;
         }
 
-        _currentPlayer?.Play();
+        player.FinishedPlaying += (_, _) =>
+        {
+            lock (_active) _active.Remove(player);
+            player.Dispose();
+        };
+        lock (_active) _active.Add(player);
+        player.Play();
     }
 }

--- a/sys/version.h
+++ b/sys/version.h
@@ -5,7 +5,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 6
-#define VERSION_PATCH 43
+#define VERSION_PATCH 44
 
-#define VERSION "26.6.43"
+#define VERSION "26.6.44"
 #define VERSION_DATE "2026-06-27"


### PR DESCRIPTION
Follow-up to #12 (landed after that PR merged).

**Problem:** section on/off sounds played inconsistently on Android. `AudioService` used a single shared `MediaPlayer` and released the still-playing instance before each new sound, so sounds fired in quick succession (multiple sections toggling) cut each other off. Autosteer — a single isolated event — was unaffected, which matched the symptom exactly.

**Fix:** each play gets its own self-releasing player so they overlap, with `PrepareAsync` so the host control loop (which raises these) doesn't block on prepare; callbacks land on the main looper. Fixed the identical single-player bug in the iOS `AVAudioPlayer` service for parity (keeps players alive in a set until `FinishedPlaying`, else GC stops the sound mid-play).

Device-verified on the Galaxy Tab S7 FE. v26.6.44.

🤖 Generated with [Claude Code](https://claude.com/claude-code)