### PR TITLE
Android SELinux-safe atomic save; remove dead avares:// icon helpers

### DIFF
--- a/Shared/AgOpenWeb.Models/Configuration/VehicleConfig.cs
+++ b/Shared/AgOpenWeb.Models/Configuration/VehicleConfig.cs
@@ -45,14 +45,6 @@ public class VehicleConfig : ObservableObject
             if (oldValue != value)
             {
                 // Notify computed properties that depend on Type
-                OnPropertyChanged(nameof(WheelbaseImageSource));
-                OnPropertyChanged(nameof(WheelbaseCropImageSource));
-                OnPropertyChanged(nameof(HitchCropImageSource));
-                OnPropertyChanged(nameof(HasHitchImage));
-                OnPropertyChanged(nameof(TrackWidthImageSource));
-                OnPropertyChanged(nameof(AntennaImageSource));
-                OnPropertyChanged(nameof(AntennaSideImageSource));
-                OnPropertyChanged(nameof(AntennaOffsetImageSource));
                 OnPropertyChanged(nameof(VehicleTypeDisplayName));
             }
         }
@@ -151,83 +143,6 @@ public class VehicleConfig : ObservableObject
     // Computed properties
     public double MinTurningRadius => Wheelbase / Math.Tan(MaxSteerAngle * Math.PI / 180.0);
 
-    /// <summary>
-    /// Gets the image source for the wheelbase/track diagram based on vehicle type
-    /// </summary>
-    public string WheelbaseImageSource => Type switch
-    {
-        VehicleType.Harvester => "avares://AgOpenWeb.Views/Assets/Icons/RadiusWheelBaseHarvester.png",
-        VehicleType.FourWD => "avares://AgOpenWeb.Views/Assets/Icons/RadiusWheelBaseArticulated.png",
-        _ => "avares://AgOpenWeb.Views/Assets/Icons/RadiusWheelBase.png"
-    };
-
-    /// <summary>
-    /// Cropped wheelbase diagram (focused on the axle span) for the dimensions UI.
-    /// </summary>
-    public string WheelbaseCropImageSource => Type switch
-    {
-        VehicleType.Harvester => "avares://AgOpenWeb.Views/Assets/Icons/WheelbaseHarvester.png",
-        VehicleType.FourWD => "avares://AgOpenWeb.Views/Assets/Icons/WheelbaseArticulated.png",
-        _ => "avares://AgOpenWeb.Views/Assets/Icons/WheelbaseTractor.png"
-    };
-
-    /// <summary>
-    /// Track-width diagram (left-to-right wheel centers) for the dimensions UI.
-    /// </summary>
-    public string TrackWidthImageSource => Type switch
-    {
-        VehicleType.Harvester => "avares://AgOpenWeb.Views/Assets/Icons/TrackWidthHarvester.png",
-        VehicleType.FourWD => "avares://AgOpenWeb.Views/Assets/Icons/TrackWidthArticulated.png",
-        _ => "avares://AgOpenWeb.Views/Assets/Icons/TrackWidthTractor.png"
-    };
-
-    /// <summary>
-    /// Top-down hitch diagram (rear axle &#8594; hitch pin) for the dimensions UI card.
-    /// Tractor and articulated have their own top-down art; harvester has no hitch
-    /// diagram (matches AgOpen, which shows none for harvesters).
-    /// </summary>
-    public string HitchCropImageSource => Type switch
-    {
-        VehicleType.FourWD => "avares://AgOpenWeb.Views/Assets/Icons/HitchArticulated.png",
-        VehicleType.Harvester => string.Empty,
-        _ => "avares://AgOpenWeb.Views/Assets/Icons/Hitch.png"
-    };
-
-    /// <summary>
-    /// Whether a hitch diagram exists for the current vehicle type (false for harvester).
-    /// </summary>
-    public bool HasHitchImage => Type != VehicleType.Harvester;
-
-    /// <summary>
-    /// Gets the image source for the antenna position diagram based on vehicle type
-    /// </summary>
-    public string AntennaImageSource => Type switch
-    {
-        VehicleType.Harvester => "avares://AgOpenWeb.Views/Assets/Icons/AntennaHarvester.png",
-        VehicleType.FourWD => "avares://AgOpenWeb.Views/Assets/Icons/AntennaArticulated.png",
-        _ => "avares://AgOpenWeb.Views/Assets/Icons/AntennaTractor.png"
-    };
-
-    /// <summary>
-    /// Side-view antenna diagram (fore/aft pivot distance + antenna height) for the
-    /// dimensions UI card.
-    /// </summary>
-    public string AntennaSideImageSource => Type switch
-    {
-        VehicleType.Harvester => "avares://AgOpenWeb.Views/Assets/Icons/AntennaHarvesterTop.png",
-        VehicleType.FourWD => "avares://AgOpenWeb.Views/Assets/Icons/AntennaArticulatedTop.png",
-        _ => "avares://AgOpenWeb.Views/Assets/Icons/AntennaTractorTop.png"
-    };
-
-    /// <summary>
-    /// Top-down antenna diagram (left/right offset from centerline) for the dimensions UI card.
-    /// </summary>
-    public string AntennaOffsetImageSource => Type switch
-    {
-        VehicleType.Harvester => "avares://AgOpenWeb.Views/Assets/Icons/AntennaHarvesterOffset.png",
-        VehicleType.FourWD => "avares://AgOpenWeb.Views/Assets/Icons/AntennaArticulatedOffset.png",
-        _ => "avares://AgOpenWeb.Views/Assets/Icons/AntennaTractorOffset.png"
-    };
 
     /// <summary>
     /// Gets a user-friendly display name for the current vehicle type

--- a/Shared/AgOpenWeb.Services/Storage/AtomicJsonFile.cs
+++ b/Shared/AgOpenWeb.Services/Storage/AtomicJsonFile.cs
@@ -119,6 +119,16 @@ public static class AtomicJsonFile
             return;
         }
 
+        // Android SELinux (e.g. Samsung's policy) denies BOTH the hard link() that File.Replace
+        // uses and the FICLONE/reflink ioctl that File.Copy attempts — every save logged audit
+        // denials and only worked by accident via the catch below. Go straight to a rename-based
+        // promote with a manual stream-copy backup: rename() and plain read/write are allowed.
+        if (OperatingSystem.IsAndroid())
+        {
+            RotateAndMove(tmp, path, bak);
+            return;
+        }
+
         try
         {
             // File.Replace is atomic on Windows and POSIX and rolls the current
@@ -130,9 +140,28 @@ public static class AtomicJsonFile
             // Some filesystems (certain Android/exFAT mounts) reject Replace.
             // Fall back to a manual rotate: keep the current file as backup,
             // then move the scratch file into place.
-            try { File.Copy(path, bak, overwrite: true); } catch { /* best-effort backup */ }
-            File.Move(tmp, path, overwrite: true);
+            RotateAndMove(tmp, path, bak);
         }
+    }
+
+    /// <summary>Backup-then-rename promote using only allowed syscalls (no hard link, no
+    /// FICLONE ioctl): stream-copy the current primary to the backup, then rename the scratch
+    /// over the primary. A crash leaves either the old file (in place or as backup) or the new
+    /// one — never a partial primary.</summary>
+    private static void RotateAndMove(string tmp, string path, string bak)
+    {
+        try { CopyBytes(path, bak); } catch { /* best-effort backup */ }
+        File.Move(tmp, path, overwrite: true);
+    }
+
+    /// <summary>Plain stream copy — deliberately NOT File.Copy, whose reflink/FICLONE ioctl is
+    /// denied by some Android SELinux policies.</summary>
+    private static void CopyBytes(string src, string dest)
+    {
+        using var s = new FileStream(src, FileMode.Open, FileAccess.Read, FileShare.Read);
+        using var d = new FileStream(dest, FileMode.Create, FileAccess.Write, FileShare.None);
+        s.CopyTo(d);
+        d.Flush(flushToDisk: true);
     }
 
     /// <summary>

--- a/Shared/AgOpenWeb.ViewModels/MainViewModel.Commands.Track.cs
+++ b/Shared/AgOpenWeb.ViewModels/MainViewModel.Commands.Track.cs
@@ -994,7 +994,6 @@ public partial class MainViewModel
 
             ConfigStore.Guidance.TramDisplay = tram.DisplayMode != Models.Configuration.TramDisplayMode.Off;
             UpdateTramLines(SelectedTrack);
-            OnPropertyChanged(nameof(TramDisplayIcon));
             OnPropertyChanged(nameof(TramDisplayLabel));
             StatusMessage = tram.DisplayMode switch
             {
@@ -1021,7 +1020,6 @@ public partial class MainViewModel
             ConfigStore.Tram.DisplayMode = Models.Configuration.TramDisplayMode.All;
             ConfigStore.Guidance.TramDisplay = true;
             UpdateTramLines(SelectedTrack);
-            OnPropertyChanged(nameof(TramDisplayIcon));
             OnPropertyChanged(nameof(TramDisplayLabel));
             StatusMessage = ConfigStore.Tram.Systems.Count > 0
                 ? $"Tram lines built from {ConfigStore.Tram.Systems.Count} system(s)"
@@ -1067,7 +1065,6 @@ public partial class MainViewModel
             ConfigStore.Tram.DisplayMode = mode;
             ConfigStore.Guidance.TramDisplay = mode != Models.Configuration.TramDisplayMode.Off;
             UpdateTramLines(SelectedTrack);
-            OnPropertyChanged(nameof(TramDisplayIcon));
             OnPropertyChanged(nameof(TramDisplayLabel));
         }
 

--- a/Shared/AgOpenWeb.ViewModels/MainViewModel.cs
+++ b/Shared/AgOpenWeb.ViewModels/MainViewModel.cs
@@ -4020,14 +4020,6 @@ public partial class MainViewModel : ObservableObject
     public ICommand? IncreaseTramLineCommand { get; private set; }
     public ICommand? DecreaseTramLineCommand { get; private set; }
 
-    public string TramDisplayIcon => ConfigStore.Tram.DisplayMode switch
-    {
-        Models.Configuration.TramDisplayMode.All => "avares://AgOpenWeb.Views/Assets/Icons/TramAll.png",
-        Models.Configuration.TramDisplayMode.LinesOnly => "avares://AgOpenWeb.Views/Assets/Icons/TramLines.png",
-        Models.Configuration.TramDisplayMode.OuterOnly => "avares://AgOpenWeb.Views/Assets/Icons/TramOuter.png",
-        _ => "avares://AgOpenWeb.Views/Assets/Icons/TramOff.png"
-    };
-
     public string TramDisplayLabel => ConfigStore.Tram.DisplayMode switch
     {
         Models.Configuration.TramDisplayMode.All => "All",

--- a/Shared/AgOpenWeb.ViewModels/Wizards/SteerWizard/AntennaSetupStepViewModel.cs
+++ b/Shared/AgOpenWeb.ViewModels/Wizards/SteerWizard/AntennaSetupStepViewModel.cs
@@ -68,25 +68,6 @@ public class AntennaSetupStepViewModel : WizardStepViewModel
     public ICommand SetCenterCommand { get; }
     public ICommand SetRightCommand { get; }
 
-    /// <summary>Antenna icon path matching the current vehicle type.</summary>
-    public string AntennaIconSource => _configService.Store.Vehicle.AntennaImageSource;
-
-    /// <summary>Top crop: pivot distance + height view.</summary>
-    public string AntennaTopImageSource => _configService.Store.Vehicle.Type switch
-    {
-        Models.VehicleType.Harvester => "avares://AgOpenWeb.Views/Assets/Icons/AntennaHarvesterTop.png",
-        Models.VehicleType.FourWD => "avares://AgOpenWeb.Views/Assets/Icons/AntennaArticulatedTop.png",
-        _ => "avares://AgOpenWeb.Views/Assets/Icons/AntennaTractorTop.png"
-    };
-
-    /// <summary>Bottom-left crop: lateral offset view.</summary>
-    public string AntennaOffsetImageSource => _configService.Store.Vehicle.Type switch
-    {
-        Models.VehicleType.Harvester => "avares://AgOpenWeb.Views/Assets/Icons/AntennaHarvesterOffset.png",
-        Models.VehicleType.FourWD => "avares://AgOpenWeb.Views/Assets/Icons/AntennaArticulatedOffset.png",
-        _ => "avares://AgOpenWeb.Views/Assets/Icons/AntennaTractorOffset.png"
-    };
-
     public AntennaSetupStepViewModel(IConfigurationService configService)
     {
         _configService = configService;
@@ -102,7 +83,6 @@ public class AntennaSetupStepViewModel : WizardStepViewModel
         AntennaPivot = vehicle.AntennaPivot;
         AntennaHeight = vehicle.AntennaHeight;
         AntennaOffset = vehicle.AntennaOffset;
-        OnPropertyChanged(nameof(AntennaIconSource));
     }
 
     protected override void OnLeaving()

--- a/Shared/AgOpenWeb.ViewModels/Wizards/SteerWizard/VehicleDimensionsStepViewModel.cs
+++ b/Shared/AgOpenWeb.ViewModels/Wizards/SteerWizard/VehicleDimensionsStepViewModel.cs
@@ -48,28 +48,6 @@ public class VehicleDimensionsStepViewModel : WizardStepViewModel
         set => SetProperty(ref _trackWidth, value);
     }
 
-    /// <summary>
-    /// Wheelbase diagram image path matching the current vehicle type.
-    /// </summary>
-    public string WheelbaseImageSource => _configService.Store.Vehicle.WheelbaseImageSource;
-
-    /// <summary>
-    /// Cropped wheelbase diagram focused on the wheel area.
-    /// </summary>
-    public string WheelbaseCropImageSource => _configService.Store.Vehicle.Type switch
-    {
-        Models.VehicleType.Harvester => "avares://AgOpenWeb.Views/Assets/Icons/WheelbaseHarvester.png",
-        Models.VehicleType.FourWD => "avares://AgOpenWeb.Views/Assets/Icons/WheelbaseArticulated.png",
-        _ => "avares://AgOpenWeb.Views/Assets/Icons/WheelbaseTractor.png"
-    };
-
-    public string TrackWidthImageSource => _configService.Store.Vehicle.Type switch
-    {
-        Models.VehicleType.Harvester => "avares://AgOpenWeb.Views/Assets/Icons/TrackWidthHarvester.png",
-        Models.VehicleType.FourWD => "avares://AgOpenWeb.Views/Assets/Icons/TrackWidthArticulated.png",
-        _ => "avares://AgOpenWeb.Views/Assets/Icons/TrackWidthTractor.png"
-    };
-
     public VehicleDimensionsStepViewModel(IConfigurationService configService)
     {
         _configService = configService;
@@ -80,7 +58,6 @@ public class VehicleDimensionsStepViewModel : WizardStepViewModel
         var vehicle = _configService.Store.Vehicle;
         Wheelbase = vehicle.Wheelbase;
         TrackWidth = vehicle.TrackWidth;
-        OnPropertyChanged(nameof(WheelbaseImageSource));
     }
 
     protected override void OnLeaving()

--- a/sys/version.h
+++ b/sys/version.h
@@ -5,7 +5,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 6
-#define VERSION_PATCH 44
+#define VERSION_PATCH 45
 
-#define VERSION "26.6.44"
+#define VERSION "26.6.45"
 #define VERSION_DATE "2026-06-27"


### PR DESCRIPTION
Two follow-ups from the web-only conversion (#12), both device-verified on the Galaxy Tab S7 FE.

## 1. SELinux-safe atomic save (Android)
`AtomicJsonFile` promoted writes with `File.Replace` (hard `link()`) and a `File.Copy` fallback (`FICLONE`/reflink ioctl). Samsung's SELinux policy **denies both**, so every config/state save logged `avc: denied` audit entries and only succeeded by luck through the catch path.

Fix: on Android (and in the non-Android fallback), use a rename-based promote — stream-copy the current primary to `.bak` with a plain read/write (not `File.Copy`), then `File.Move(overwrite)` the scratch over the primary. `rename()` + byte copies are allowed; still crash-safe (either the old or new file survives, never a partial primary). **Verified:** a save now produces no `avc: denied` entries and `appstate.json` updates.

## 2. Remove dead `avares://` icon helpers
Left over from the deleted native UI: `VehicleConfig.*ImageSource` (+ `HasHitchImage`), the SteerWizard step VMs' icon properties, and `MainViewModel.TramDisplayIcon`, plus their `OnPropertyChanged` notifications. The web client renders its own `wwwroot` icons and `WizardDto` carries no image fields, so nothing consumed these (confirmed). No more `avares://AgOpenWeb.Views/...` references remain in the codebase.

Desktop / Android / iOS build; Models (146) / Services (1018) / ViewModels (222) tests pass. v26.6.45.

🤖 Generated with [Claude Code](https://claude.com/claude-code)