### PR TITLE
CI: rename Android signing key agvalonia -> agopenweb

### DIFF
--- a/.github/workflows/build-deploy-bundles.yml
+++ b/.github/workflows/build-deploy-bundles.yml
@@ -176,16 +176,17 @@ jobs:
       - name: Restore dependencies
         run: dotnet restore Platforms/AgOpenWeb.Android/AgOpenWeb.Android.csproj
 
-      # Use the committed release keystore (stable signing identity for over-the-top updates);
-      # fall back to the ephemeral debug key with a warning if the secret is absent.
+      # AgOpenWeb release keystore (supplied via the ANDROID_KEYSTORE_BASE64 secret) — a stable
+      # signing identity for over-the-top updates; falls back to the ephemeral debug key with a
+      # warning if the secret is absent.
       - name: Decode signing keystore
         id: keystore
         env:
           KEYSTORE_B64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
         run: |
           if [ -n "$KEYSTORE_B64" ]; then
-            echo "$KEYSTORE_B64" | base64 -d > "$RUNNER_TEMP/agvalonia-release.keystore"
-            echo "path=$RUNNER_TEMP/agvalonia-release.keystore" >> "$GITHUB_OUTPUT"
+            echo "$KEYSTORE_B64" | base64 -d > "$RUNNER_TEMP/agopenweb-release.keystore"
+            echo "path=$RUNNER_TEMP/agopenweb-release.keystore" >> "$GITHUB_OUTPUT"
             echo "present=true" >> "$GITHUB_OUTPUT"
           else
             echo "present=false" >> "$GITHUB_OUTPUT"
@@ -201,7 +202,7 @@ jobs:
           if [ "${{ steps.keystore.outputs.present }}" = "true" ]; then
             ARGS+=(-p:AndroidKeyStore=true
                    "-p:AndroidSigningKeyStore=${{ steps.keystore.outputs.path }}"
-                   -p:AndroidSigningKeyAlias=agvalonia
+                   -p:AndroidSigningKeyAlias=agopenweb
                    -p:AndroidSigningStorePass=env:KS_PASS
                    -p:AndroidSigningKeyPass=env:KS_PASS)
           fi

--- a/sys/version.h
+++ b/sys/version.h
@@ -5,7 +5,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 6
-#define VERSION_PATCH 45
+#define VERSION_PATCH 46
 
-#define VERSION "26.6.45"
+#define VERSION "26.6.46"
 #define VERSION_DATE "2026-06-27"


### PR DESCRIPTION
Post-fork tidy-up — the release keystore/alias still carried the old AgValoniaGPS name.

- `keytool -changealias agvalonia -> agopenweb` (same cert/key, so the signing identity is unchanged)
- renamed the local keystore file; updated the workflow's `AndroidSigningKeyAlias`, temp filename, and stale comment
- `ANDROID_KEYSTORE_BASE64` re-set from the relabeled keystore; `ANDROID_KEYSTORE_PASSWORD` unchanged

CI-internal only (not user-visible; package id stays `com.agopenweb.android`). v26.6.46.

🤖 Generated with [Claude Code](https://claude.com/claude-code)