### PR TITLE
U-turn: default to Sagitta, retire Dubins as a selectable style

### DIFF
--- a/Shared/AgOpenWeb.Models/Configuration/GuidanceConfig.cs
+++ b/Shared/AgOpenWeb.Models/Configuration/GuidanceConfig.cs
@@ -17,6 +17,8 @@
 using System;
 using CommunityToolkit.Mvvm.ComponentModel;
 
+using AgOpenWeb.Models.YouTurn;
+
 namespace AgOpenWeb.Models.Configuration;
 
 /// <summary>
@@ -149,7 +151,12 @@ public class GuidanceConfig : ObservableObject
         set => SetProperty(ref _uTurnSkipWidth, Math.Max(1, value));
     }
 
-    private int _uTurnStyle;
+    // Sagitta (offset-semicircle) by default — matches Twol, which dropped Dubins
+    // for U-turns because the shortest-path solution loops ("np" shape) whenever the
+    // next row is closer than 2× the turn radius. SagittaStyle == 0, so profiles
+    // persisted under the old numbering (0 = Albin/Dubins) land on Sagitta with no
+    // migration. Dubins survives only as the internal >2R wide-turn fallback.
+    private int _uTurnStyle = (int)YouTurnType.SagittaStyle;
     public int UTurnStyle
     {
         get => _uTurnStyle;

--- a/Shared/AgOpenWeb.Models/YouTurn/YouTurnType.cs
+++ b/Shared/AgOpenWeb.Models/YouTurn/YouTurnType.cs
@@ -22,26 +22,26 @@ namespace AgOpenWeb.Models.YouTurn
     public enum YouTurnType
     {
         /// <summary>
-        /// Omega or Wide turn (based on offset width).
-        /// Uses Dubins paths for omega, semicircles for wide.
+        /// Sagitta turn (Brian Tischler's AOG dev-fork "sagitta" U-turn) — the
+        /// default. A single offset arc with a short counter-arc lead-in so the
+        /// path meets the crop row tangentially, eliminating the straight-leg→arc
+        /// curvature step that makes Omega turns feel sharp. The sagitta (extra
+        /// arc depth) lets it connect rows closer than twice the turn radius
+        /// without looping. For rows wider than 2× the radius it adds straight
+        /// connectors via the internal Dubins omega fallback.
+        ///
+        /// Value 0 so that profiles persisted under the old numbering (where
+        /// 0 = Albin/Dubins, the looping shortest-path turn we removed) land on
+        /// Sagitta automatically — no migration needed. Twol dropped Dubins as a
+        /// selectable style for the same reason; it is no longer offered here.
         /// </summary>
-        AlbinStyle = 0,
+        SagittaStyle = 0,
 
         /// <summary>
-        /// K-style turn.
-        /// Creates a more squared-off turn pattern.
+        /// K-style turn. A more squared-off / tighter turn pattern (Twol's
+        /// alternate-sweep style).
         /// </summary>
-        KStyle = 1,
-
-        /// <summary>
-        /// Sagitta turn (Brian Tischler's AOG dev-fork "sagitta" U-turn).
-        /// A single offset arc with a short counter-arc lead-in so the path
-        /// meets the crop row tangentially, eliminating the straight-leg→arc
-        /// curvature step that makes Omega turns feel sharp. The sagitta
-        /// (extra arc depth) lets it connect rows closer than twice the turn
-        /// radius without falling back to a teardrop.
-        /// </summary>
-        SagittaStyle = 2
+        KStyle = 1
     }
 
     /// <summary>

--- a/Shared/AgOpenWeb.RemoteServer/wwwroot/app.js
+++ b/Shared/AgOpenWeb.RemoteServer/wwwroot/app.js
@@ -3546,8 +3546,8 @@ const UTI = {
   typePath: document.getElementById('uti-typepath'),
 };
 const UTURN_GLYPH = {
-  0: 'M9 34 L9 22 A11 11 0 0 1 31 22 L31 34',  // Omega — squared inverted-U
-  1: 'M7 34 Q7 20 20 20 Q33 20 33 34',         // Sagitta — flatter rounded arch
+  0: 'M7 34 Q7 20 20 20 Q33 20 33 34',         // Sagitta (default) — flatter rounded arch
+  1: 'M9 34 L9 22 A11 11 0 0 1 31 22 L31 34',  // K-turn — squared/tighter inverted-U
 };
 function renderUTurnIndicator() {
   if (!UTI.root) return;

--- a/Shared/AgOpenWeb.RemoteServer/wwwroot/index.html
+++ b/Shared/AgOpenWeb.RemoteServer/wwwroot/index.html
@@ -179,7 +179,7 @@
     .osb-btn svg { width: 100%; height: 100%; display: block; pointer-events: none; }
     /* Auto-U-turn approach indicator — upper-right, symmetric to #onscreenbtns. Display
        only (click-through). Direction arrow flips for a left turn; distance below it; the
-       turn-type glyph (Omega/Sagitta) to the right. */
+       turn-type glyph (Sagitta/K-turn) to the right. */
     #uturn-indicator { position: fixed; top: calc(96px + var(--sat)); right: calc(126px + var(--sar));
       display: flex; align-items: center; gap: 14px; z-index: 20; pointer-events: none;
       filter: drop-shadow(0 1px 3px rgba(0,0,0,0.85)); }
@@ -1093,7 +1093,7 @@
     </div>
   </div>
   <!-- Auto-U-turn approach indicator (native look) — green direction arrow + distance to
-       trigger + turn-type glyph (Omega / Sagitta). Upper-right, symmetric to the on-screen
+       trigger + turn-type glyph (Sagitta / K-turn). Upper-right, symmetric to the on-screen
        U-turn/Lateral buttons. Display only; shown while an auto U-turn is armed. -->
   <div id="uturn-indicator" hidden>
     <div class="uti-distbox">
@@ -1436,8 +1436,8 @@
     <div id="tc-uturn" class="cfg-body" data-strip="tc-top" hidden>
       <div class="cfg-label">Turn style</div>
       <div class="ln-seg cfg-seg-full">
-        <button class="cfg-typebtn" data-key="uturn.style" data-val="0" data-active="0">Omega</button>
-        <button class="cfg-typebtn" data-key="uturn.style" data-val="1" data-active="1">Sagitta</button>
+        <button class="cfg-typebtn" data-key="uturn.style" data-val="0">Sagitta</button>
+        <button class="cfg-typebtn" data-key="uturn.style" data-val="1">K-turn</button>
       </div>
       <div class="cfg-diaggrid">
         <div class="vc-diagrow"><img src="/icons/ConU_UturnLength.png" class="vc-diag" alt=""><div class="vc-fieldcol"><label>Extension (m)</label><input class="cfg-num" data-key="uturn.extension" type="number" step="0.1"></div></div>

--- a/Shared/AgOpenWeb.Services/Pipeline/GpsPipelineService.cs
+++ b/Shared/AgOpenWeb.Services/Pipeline/GpsPipelineService.cs
@@ -1452,7 +1452,7 @@ public sealed class GpsPipelineService : IGpsPipelineService
             FixHeading = headingRad,
             AvgSpeed = speedKmh,
             IsReverse = false,
-            UTurnStyle = 0
+            UTurnStyle = config.Guidance.UTurnStyle
         };
 
         var output = _youTurnGuidanceService.CalculateGuidance(input);

--- a/Shared/AgOpenWeb.Services/Profile/ProfileJsonServiceV1.cs
+++ b/Shared/AgOpenWeb.Services/Profile/ProfileJsonServiceV1.cs
@@ -261,7 +261,7 @@ public static class ProfileJsonServiceV1
         store.Guidance.UTurnExtension = dto.YouTurn?.ExtensionLength ?? 20.0;
         store.Guidance.UTurnDistanceFromBoundary = dto.YouTurn?.DistanceFromBoundary ?? 2.0;
         store.Guidance.UTurnSkipWidth = dto.YouTurn?.SkipWidth ?? 1;
-        store.Guidance.UTurnStyle = dto.YouTurn?.Style ?? 0;
+        store.Guidance.UTurnStyle = dto.YouTurn?.Style ?? (int)Models.YouTurn.YouTurnType.SagittaStyle;
         store.Guidance.UTurnSmoothing = dto.YouTurn?.Smoothing ?? 14;
 
         // Tool config

--- a/Shared/AgOpenWeb.Services/Profile/VehicleProfileJsonService.cs
+++ b/Shared/AgOpenWeb.Services/Profile/VehicleProfileJsonService.cs
@@ -205,7 +205,7 @@ public static class VehicleProfileJsonService
         store.Guidance.UTurnExtension = dto.YouTurn?.ExtensionLength ?? 20.0;
         store.Guidance.UTurnDistanceFromBoundary = dto.YouTurn?.DistanceFromBoundary ?? 2.0;
         store.Guidance.UTurnSkipWidth = dto.YouTurn?.SkipWidth ?? 1;
-        store.Guidance.UTurnStyle = dto.YouTurn?.Style ?? 0;
+        store.Guidance.UTurnStyle = dto.YouTurn?.Style ?? (int)Models.YouTurn.YouTurnType.SagittaStyle;
         store.Guidance.UTurnSmoothing = dto.YouTurn?.Smoothing ?? 14;
 
         // General — IsMetric used to live here; it now lives in AppSettings.

--- a/Shared/AgOpenWeb.Services/VehicleProfileService.cs
+++ b/Shared/AgOpenWeb.Services/VehicleProfileService.cs
@@ -231,7 +231,7 @@ public class VehicleProfileService : IVehicleProfileService
         store.Guidance.UTurnExtension = 20.0;
         store.Guidance.UTurnDistanceFromBoundary = 2.0;
         store.Guidance.UTurnSkipWidth = 1;
-        store.Guidance.UTurnStyle = 0;
+        store.Guidance.UTurnStyle = (int)Models.YouTurn.YouTurnType.SagittaStyle; // Sagitta default (Twol parity; no Dubins loop)
         store.Guidance.UTurnSmoothing = 14;
 
         store.Tool.Width = 6.0;
@@ -304,7 +304,7 @@ public class VehicleProfileService : IVehicleProfileService
         store.Guidance.UTurnExtension = GetDouble(settings, "set_youTurnExtensionLength", 20.0);
         store.Guidance.UTurnDistanceFromBoundary = GetDouble(settings, "set_youTurnDistanceFromBoundary", 2.0);
         store.Guidance.UTurnSkipWidth = GetInt(settings, "set_youSkipWidth", 1);
-        store.Guidance.UTurnStyle = GetInt(settings, "set_uTurnStyle", 0);
+        store.Guidance.UTurnStyle = GetInt(settings, "set_uTurnStyle", (int)Models.YouTurn.YouTurnType.SagittaStyle);
         store.Guidance.UTurnSmoothing = GetInt(settings, "setAS_uTurnSmoothing", 14);
 
         // Tool config

--- a/Shared/AgOpenWeb.Services/YouTurn/YouTurnCreationService.Orchestration.cs
+++ b/Shared/AgOpenWeb.Services/YouTurn/YouTurnCreationService.Orchestration.cs
@@ -57,14 +57,14 @@ public partial class YouTurnCreationService
 
     /// <summary>
     /// Maps the persisted <see cref="GuidanceConfig.UTurnStyle"/> integer onto the
-    /// creation <see cref="YouTurnType"/>. 0 = Omega/Wide (Albin), 1 = K-style,
-    /// 2 = Sagitta. Unknown values fall back to the Albin default.
+    /// creation <see cref="YouTurnType"/>. 0 = Sagitta (default), 1 = K-style.
+    /// Unknown values — including the retired Albin/Dubins style and any old
+    /// numbering — fall back to Sagitta.
     /// </summary>
     private static YouTurnType MapTurnStyle(int uTurnStyle) => uTurnStyle switch
     {
         (int)YouTurnType.KStyle => YouTurnType.KStyle,
-        (int)YouTurnType.SagittaStyle => YouTurnType.SagittaStyle,
-        _ => YouTurnType.AlbinStyle,
+        _ => YouTurnType.SagittaStyle,
     };
 
     /// <summary>

--- a/Shared/AgOpenWeb.Services/YouTurn/YouTurnCreationService.cs
+++ b/Shared/AgOpenWeb.Services/YouTurn/YouTurnCreationService.cs
@@ -151,22 +151,18 @@ namespace AgOpenWeb.Services.YouTurn
 
         private bool CreateCurveTurn(YouTurnCreationInput input, double turnOffset)
         {
-            if (input.TurnType == YouTurnType.SagittaStyle)
-            {
-                return CreateCurveSagittaTurn(input, turnOffset);
-            }
-            else if (input.TurnType == YouTurnType.AlbinStyle)
-            {
-                // Always use the omega turn: it uses Dubins paths which handle any
-                // turnOffset, and it completes in a single call. The multi-phase wide
-                // turn can't finish under the single-call CreateTurn contract (same
-                // reason CreateABTurn always uses the omega path).
-                return CreateCurveOmegaTurn(input, turnOffset);
-            }
-            else // KStyle
+            if (input.TurnType == YouTurnType.KStyle)
             {
                 return CreateKStyleTurnCurve(input, turnOffset);
             }
+
+            // SagittaStyle (default, and the fallback for any retired/unknown style).
+            // The sagitta arc itself only spans rows up to 2× the turn radius; wider
+            // rows are handled inside CreateCurveSagittaTurn, which delegates to the
+            // Dubins omega (CreateCurveOmegaTurn) for the straight-connector case.
+            // Dubins is kept ONLY as that internal wide-turn fallback — it is no longer
+            // a selectable style, because its shortest-path solution loops on close rows.
+            return CreateCurveSagittaTurn(input, turnOffset);
         }
 
         private bool CreateCurveOmegaTurn(YouTurnCreationInput input, double turnOffset)

--- a/Shared/AgOpenWeb.ViewModels/ConfigurationViewModel.cs
+++ b/Shared/AgOpenWeb.ViewModels/ConfigurationViewModel.cs
@@ -966,15 +966,16 @@ public partial class ConfigurationViewModel : ObservableObject
     public ICommand EditUTurnSkipWidthCommand { get; private set; } = null!;
     public ICommand EditUTurnSmoothingCommand { get; private set; } = null!;
 
-    // U-Turn style selector (0 = Omega/Albin, 2 = Sagitta)
-    public ICommand SetOmegaTurnStyleCommand { get; private set; } = null!;
+    // U-Turn style selector (0 = Sagitta [default], 1 = K-style). Dubins/Omega is
+    // no longer offered — it looped on close rows; Sagitta covers every case.
     public ICommand SetSagittaTurnStyleCommand { get; private set; } = null!;
+    public ICommand SetKTurnStyleCommand { get; private set; } = null!;
 
-    /// <summary>True when the active U-turn style is Omega (or any non-Sagitta style).</summary>
-    public bool IsOmegaTurnStyle => Guidance.UTurnStyle != (int)YouTurnType.SagittaStyle;
+    /// <summary>True when the active U-turn style is Sagitta (the default).</summary>
+    public bool IsSagittaTurnStyle => Guidance.UTurnStyle != (int)YouTurnType.KStyle;
 
-    /// <summary>True when the active U-turn style is Sagitta.</summary>
-    public bool IsSagittaTurnStyle => Guidance.UTurnStyle == (int)YouTurnType.SagittaStyle;
+    /// <summary>True when the active U-turn style is K-style.</summary>
+    public bool IsKTurnStyle => Guidance.UTurnStyle == (int)YouTurnType.KStyle;
 
     // GPS Tab Commands
     public ICommand SetSingleGpsCommand { get; private set; } = null!;
@@ -1403,8 +1404,8 @@ public partial class ConfigurationViewModel : ObservableObject
                 v => Guidance.UTurnSmoothing = (int)v,
                 "", integerOnly: true, allowNegative: false, min: 1, max: 50));
 
-        SetOmegaTurnStyleCommand = new RelayCommand(() => SetTurnStyle((int)YouTurnType.AlbinStyle));
         SetSagittaTurnStyleCommand = new RelayCommand(() => SetTurnStyle((int)YouTurnType.SagittaStyle));
+        SetKTurnStyleCommand = new RelayCommand(() => SetTurnStyle((int)YouTurnType.KStyle));
     }
 
     /// <summary>
@@ -1415,8 +1416,8 @@ public partial class ConfigurationViewModel : ObservableObject
     {
         Guidance.UTurnStyle = style;
         Config.MarkChanged();
-        OnPropertyChanged(nameof(IsOmegaTurnStyle));
         OnPropertyChanged(nameof(IsSagittaTurnStyle));
+        OnPropertyChanged(nameof(IsKTurnStyle));
     }
 
     private void InitializeGpsEditCommands()

--- a/Tests/AgOpenWeb.Services.Tests/YouTurn/UTurnSagittaDefaultTests.cs
+++ b/Tests/AgOpenWeb.Services.Tests/YouTurn/UTurnSagittaDefaultTests.cs
@@ -1,0 +1,138 @@
+// AgOpenWeb
+// Copyright (C) 2024-2026 AgOpenWeb Contributors
+//
+// Licensed under GNU GPL v3. See LICENSE.md.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using AgOpenWeb.Models;
+using AgOpenWeb.Models.Base;
+using AgOpenWeb.Models.Configuration;
+using AgOpenWeb.Models.Pipeline;
+using AgOpenWeb.Models.YouTurn;
+using AgOpenWeb.Services.Geometry;
+using AgOpenWeb.Services.YouTurn;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace AgOpenWeb.Services.Tests.YouTurn;
+
+/// <summary>
+/// Locks in the U-turn default = Sagitta (Twol parity). AlbinStyle uses Dubins
+/// shortest-path, which loops ("np" shape) whenever the next row is closer than
+/// 2× the turn radius — a clean 180° arc of radius R lands 2R sideways, so to
+/// reach a nearer row it overshoots and adds a counter-loop. Sagitta is a single
+/// offset-semicircle that lands exactly on the row with no loop. Brian removed
+/// Dubins from Twol for this reason; these tests guard the default and the
+/// loop-free property at the borderline rig (tool == 2R).
+/// </summary>
+[TestFixture]
+[NonParallelizable] // ConfigurationStore is a singleton.
+public class UTurnSagittaDefaultTests
+{
+    [Test]
+    public void DefaultUTurnStyle_IsSagitta()
+    {
+        var store = new ConfigurationStore();
+        Assert.That(store.Guidance.UTurnStyle, Is.EqualTo((int)YouTurnType.SagittaStyle),
+            "U-turn style must default to Sagitta — AlbinStyle (Dubins) loops on close rows.");
+    }
+
+    [Test]
+    public void DefaultTurn_AtBorderlineRig_DoesNotLoop()
+    {
+        // Tool 16 m, radius 8 m => 2R == tool width: adjacent-row spacing sits right
+        // at the Dubins loop threshold (and tips under it with any overlap). This is
+        // the exact rig that produced the operator's looping turn on AlbinStyle.
+        ConfigurationStore.SetInstance(new ConfigurationStore());
+        var config = ConfigurationStore.Instance;
+        config.Vehicle.Wheelbase = 2.5;
+        config.Tool.Width = 16;
+        config.Tool.Overlap = 0.5;          // tips turnOffset just under 2R
+        config.NumSections = 1;
+        config.Tool.SetSectionWidth(0, 1600);
+        config.Guidance.UTurnRadius = 8.0;
+        config.Guidance.UTurnExtension = 2.0;
+        config.Guidance.UTurnSmoothing = 4;
+        config.Guidance.UTurnDistanceFromBoundary = 0;
+        // NB: do NOT set UTurnStyle — exercise the shipped default.
+
+        var creation = new YouTurnCreationService(
+            NullLogger<YouTurnCreationService>.Instance, new PolygonOffsetService(), config);
+
+        var boundary = new Boundary
+        {
+            OuterBoundary = new BoundaryPolygon
+            {
+                Points = new List<Vec2> { new(-100, -100), new(100, -100), new(100, 100), new(-100, 100) }
+                    .Select(p => new BoundaryPoint(p.Easting, p.Northing, 0)).ToList(),
+            },
+        };
+        var headlandLine = new List<Vec3>
+        {
+            new(-90, -90, 0), new(90, -90, 0), new(90, 90, 0), new(-90, 90, 0),
+        };
+        var track = Models.Track.Track.FromABLine("AB", new Vec3(0, -200, 0), new Vec3(0, 200, 0));
+
+        double turnOffset = config.ActualToolWidth - config.Tool.Overlap;
+        var guidance = new GuidanceWorkingState { HowManyPathsAway = 1, IsHeadingSameWay = true };
+        var turn = new YouTurnWorkingState { IsEnabled = true, IsTurnLeft = false, NextTrackTurnOffset = turnOffset };
+        var pos = new Position { Easting = turnOffset, Northing = 80, Heading = 0 };
+
+        var result = creation.CreateTurnPath(
+            pos, track, headingRadians: 0, abHeading: 0,
+            boundary, headlandLine, guidance, turn,
+            uTurnSkipRows: 0, headlandCalculatedWidth: 10.0, headlandDistance: 5.0);
+
+        Assert.That(result.Path, Is.Not.Null);
+        Assert.That(result.Path!.Count, Is.GreaterThan(10));
+
+        double cumDeg = CumulativeTurnDegrees(result.Path);
+        // A clean U-turn is ~180°. The Dubins RLR loop is ~320°. Anything past ~230°
+        // means the path doubled back on itself — the regression we're guarding.
+        Assert.That(cumDeg, Is.LessThan(230.0),
+            $"Turn path accumulated {cumDeg:F0}° of turning — that's the Dubins loop, not a clean U-turn.");
+        Assert.That(HasSelfIntersection(result.Path), Is.False,
+            "Turn path self-intersects — looping turn regression.");
+    }
+
+    private static double CumulativeTurnDegrees(List<Vec3> path)
+    {
+        var dirs = new List<double>();
+        for (int i = 1; i < path.Count; i++)
+        {
+            double de = path[i].Easting - path[i - 1].Easting;
+            double dn = path[i].Northing - path[i - 1].Northing;
+            if (de * de + dn * dn < 1e-6) continue;
+            dirs.Add(Math.Atan2(de, dn));
+        }
+        double cum = 0;
+        for (int i = 1; i < dirs.Count; i++)
+        {
+            double d = dirs[i] - dirs[i - 1];
+            while (d > Math.PI) d -= 2 * Math.PI;
+            while (d < -Math.PI) d += 2 * Math.PI;
+            cum += Math.Abs(d);
+        }
+        return cum * 180 / Math.PI;
+    }
+
+    private static bool HasSelfIntersection(List<Vec3> path)
+    {
+        for (int i = 0; i < path.Count - 1; i++)
+            for (int j = i + 2; j < path.Count - 1; j++)
+            {
+                if (i == 0 && j == path.Count - 2) continue;
+                if (SegmentsIntersect(path[i], path[i + 1], path[j], path[j + 1])) return true;
+            }
+        return false;
+    }
+
+    private static bool SegmentsIntersect(Vec3 p1, Vec3 p2, Vec3 p3, Vec3 p4)
+    {
+        static double D(Vec3 a, Vec3 b, Vec3 c) =>
+            (b.Easting - a.Easting) * (c.Northing - a.Northing) - (b.Northing - a.Northing) * (c.Easting - a.Easting);
+        double d1 = D(p3, p4, p1), d2 = D(p3, p4, p2), d3 = D(p1, p2, p3), d4 = D(p1, p2, p4);
+        return ((d1 > 0 && d2 < 0) || (d1 < 0 && d2 > 0)) && ((d3 > 0 && d4 < 0) || (d3 < 0 && d4 > 0));
+    }
+}

--- a/sys/version.h
+++ b/sys/version.h
@@ -5,7 +5,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 6
-#define VERSION_PATCH 52
+#define VERSION_PATCH 53
 
-#define VERSION "26.6.52"
-#define VERSION_DATE "2026-06-27"
+#define VERSION "26.6.53"
+#define VERSION_DATE "2026-06-28"


### PR DESCRIPTION
## Problem

Auto U-turns produced a looping path (the operator's "np" shape) — the arc swings right, overshoots, then curls back counter-clockwise to reach the next row. Reported on a **16 m tool / 8 m radius** rig (2R == tool width, so any overlap or skip-fill tips row spacing under the loop threshold).

Root cause: the default U-turn style was **AlbinStyle (Dubins shortest-path)**. When the next row is closer than **2× the turn radius**, the shortest Dubins solution *cannot* land on it with a clean 180° arc (a semicircle of radius R lands 2R sideways), so it overshoots and adds a counter-loop (RLR).

A deterministic repro confirmed the geometry was **identical every pass** (no accumulation) and accumulated **~320°** of turning whenever `turnOffset < 2R` — vs ~180° for a clean U-turn. Sagitta produced clean, loop-free paths (165–190°) in every case.

Twol dropped Dubins for U-turns for exactly this reason — its turns are built from the sagitta offset-semicircle (`GetOffsetSemicirclePoints`), never Dubins. AgOpenWeb's `SagittaStyle` is the equivalent (verified: its single offset-semicircle lands at exactly `turnOffset`).

## Changes

- **Renumber `YouTurnType`:** `SagittaStyle = 0`, `KStyle = 1`; remove `AlbinStyle`. Because old persisted `0` (Albin) now reads as Sagitta and old `1` (K) is unchanged, **every existing profile auto-migrates with no migration code**.
- **Dispatch:** `CreateCurveTurn` routes `K → CreateKStyleTurnCurve`, else Sagitta; `MapTurnStyle` falls back to Sagitta for any retired/unknown value. **Dubins (`CreateCurveOmegaTurn`) survives only as the internal >2R wide-turn fallback** (where its path is clean) — no longer a selectable style.
- **Fix the web turn-style selector:** it offered `Omega(0)` and `"Sagitta"(1)` — but `1` was actually KStyle and real Sagitta (`2`) was unreachable. Buttons are now `Sagitta(0, default)` / `K-turn(1)` with matching glyphs + approach indicator.
- **Plumbing:** `ConfigurationViewModel` Omega command/property → K-turn; guidance-follow input passes the configured style instead of hardcoded `0`; all default sites (live config, vehicle profile, AOG import, JSON importers) → Sagitta.
- **Regression test** `UTurnSagittaDefaultTests`: default is Sagitta + a borderline-rig turn must not loop.

## Verification

- Full solution builds (0 errors).
- Test suites green: Models 146 / ViewModels 222 / Services 1024 (+2 new).
- **Operator field-tested ~10 passes** including skips (exercises the >2R fallback) and manual U-turns — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)