### PR TITLE
Web UI: keep the fullscreen exit pill off tappable status-bar fields

### DIFF
--- a/Platforms/AgOpenWeb.Desktop/AgOpenWeb.Desktop.csproj
+++ b/Platforms/AgOpenWeb.Desktop/AgOpenWeb.Desktop.csproj
@@ -26,7 +26,7 @@
 
   <PropertyGroup>
     <IncludeSourceRevisionInInformationalVersion>true</IncludeSourceRevisionInInformationalVersion>
-    <Version>26.6.1</Version>
+    <Version>26.6.55</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Platforms/AgOpenWeb.Desktop/HeadlessHost.cs
+++ b/Platforms/AgOpenWeb.Desktop/HeadlessHost.cs
@@ -7,6 +7,7 @@
 // (at your option) any later version.
 
 using System;
+using System.Reflection;
 using System.Threading.Tasks;
 
 namespace AgOpenWeb.Desktop;
@@ -33,16 +34,30 @@ internal static class HeadlessHost
 {
     public static async Task RunAsync(string[] args)
     {
-        Console.WriteLine("[headless] AgOpenWeb host starting (no window; browser is the UI)…");
+        Console.WriteLine($"[headless] AgOpenWeb {AppVersion()} starting (no window; browser is the UI)…");
 
         var backend = new BackendHost();
         await backend.StartAsync(args);
 
-        Console.WriteLine("[headless] ready — browse to http://localhost:5174 (or the LAN IP).");
+        Console.WriteLine($"[headless] ready (v{AppVersion()}) — browse to http://localhost:5174 (or the LAN IP).");
 
         // Block until SIGINT (Ctrl-C) / SIGTERM (systemd stop) / SIGQUIT via the generic
         // host lifetime, then stop (fires the ApplicationStopping save before disposal).
         await backend.WaitForShutdownAsync();
         await backend.StopAsync();
+    }
+
+    /// <summary>
+    /// App version for the startup banner — the assembly's
+    /// AssemblyInformationalVersion, which is "&lt;Version&gt;+&lt;git-hash&gt;"
+    /// (IncludeSourceRevisionInInformationalVersion). The git hash is what lets you
+    /// tell, from the journal, exactly which build the daemon is actually running —
+    /// the bare version number alone won't if two builds share it.
+    /// </summary>
+    private static string AppVersion()
+    {
+        var asm = Assembly.GetEntryAssembly() ?? typeof(HeadlessHost).Assembly;
+        var info = asm.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+        return string.IsNullOrWhiteSpace(info) ? "unknown" : info;
     }
 }

--- a/Shared/AgOpenWeb.RemoteServer/wwwroot/app.js
+++ b/Shared/AgOpenWeb.RemoteServer/wwwroot/app.js
@@ -3418,7 +3418,14 @@ if (fsBtn) {
     if (req) { try { const p = req.call(el); if (p && p.catch) p.catch(() => {}); } catch (_) {} }
   });
   fsBtn.addEventListener('pointerdown', e => e.stopPropagation()); // don't also pan the map
-  const sync = () => { fsBtn.textContent = fsEl() ? '🗗' : '⛶'; };
+  const sync = () => {
+    const fs = !!fsEl();
+    fsBtn.textContent = fs ? '🗗' : '⛶';
+    // In fullscreen the OS draws an exit "✕" pill at the top-left (e.g. iPad Safari's
+    // Fullscreen-API control) that sits over the RTK fix + rotating info fields. We can't
+    // hide OS chrome, so nudge that left stack clear of it — only while fullscreen.
+    document.body.classList.toggle('fs-on', fs);
+  };
   document.addEventListener('fullscreenchange', sync);
   document.addEventListener('webkitfullscreenchange', sync);
 }

--- a/Shared/AgOpenWeb.RemoteServer/wwwroot/index.html
+++ b/Shared/AgOpenWeb.RemoteServer/wwwroot/index.html
@@ -85,7 +85,12 @@
     #statusbar .dot { width: 13px; height: 13px; border-radius: 50%; display: inline-block;
       background: #6b7280; vertical-align: middle; }
     #sb-pause { font-size: 12px; color: var(--text-2); }
-    .sb-left { display: flex; flex-direction: column; justify-content: center; line-height: 1.25; min-width: 360px; }
+    .sb-left { position: relative; display: flex; flex-direction: column; justify-content: center; line-height: 1.25; min-width: 360px; }
+    /* Fullscreen: the OS draws an exit "✕" pill at the top-left (e.g. iPad Safari). The
+       status bar is laid out so only the non-tappable Operator indicator sits there — nudge
+       it clear of the pill so it stays readable. Fullscreen-only (body.fs-on, toggled on
+       fullscreenchange). */
+    body.fs-on #sb-role { margin-left: 75px; }
     .sb-row1 { display: flex; align-items: center; gap: 8px; }
     .sb-sec { color: var(--text-muted); font-weight: 500; }
     .sb-rot { color: #3498DB; font-weight: 700; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
@@ -111,7 +116,7 @@
     #sb-fs:hover { background: rgba(var(--ov),0.14); }
     /* GPS-detail card (Phase 5) — popup toggled by the fix dot; mirrors GpsDetailPanel. */
     #sb-fixbtn { padding: 0; }
-    #sb-gpscard { display: none; position: absolute; top: 50px; left: 10px; min-width: 180px;
+    #sb-gpscard { display: none; position: absolute; top: calc(100% + 8px); left: 0; min-width: 180px;
       background: var(--panel); border: 1px solid var(--border); border-radius: 8px; padding: 10px 12px;
       box-shadow: 0 6px 20px rgba(0,0,0,0.5); z-index: 10; font-weight: 500; }
     #sb-gpscard .gc-ll { color: #F1C40F; font-size: 13px; font-weight: 700; font-variant-numeric: tabular-nums; }
@@ -999,18 +1004,9 @@
 <body>
   <canvas id="ck"></canvas>
   <div id="statusbar">
-    <button id="sb-pause" title="Pause / resume rotating field info">❚❚</button>
-    <div class="sb-left">
-      <div class="sb-row1">
-        <button id="sb-fixbtn" title="GPS detail">
-          <span id="sb-fixdot" class="dot"></span>
-          <span id="sb-fix">—</span>
-        </button>
-        <span id="sb-age" class="sb-sec"></span>
-      </div>
-      <div id="sb-rot" class="sb-rot">—</div>
-    </div>
-    <span class="sb-spacer"></span>
+    <!-- LEFT/RIGHT groups swapped so the fullscreen exit "✕" pill (top-left) only ever
+         sits beside the NON-tappable Operator indicator. Left group = Operator indicator,
+         Modules, Speed, Heading; everything tappable here is well right of the pill. -->
     <div id="sb-role" title="Control role"><span id="sb-roledot" class="dot"></span><span id="sb-roletext">—</span></div>
     <div class="sb-mods-wrap">
       <button id="sb-modbtn"><span id="sb-modagg" class="dot"></span>Modules</button>
@@ -1029,23 +1025,37 @@
       <span id="sb-hdg">—</span>
       <span id="sb-hdglabel">HDG</span>
     </div>
-    <button id="sb-fs" title="Fullscreen (hide browser bars)">⛶</button>
-    <!-- GPS-detail card (Phase 5): toggled by the fix dot. Anchored under the
-         left fix readout, mirroring the native GpsDetailPanel. -->
-    <div id="sb-gpscard">
-      <div class="gc-ll" id="gc-lat">—</div>
-      <div class="gc-ll" id="gc-lon">—</div>
-      <div class="gc-rule"></div>
-      <div class="gc-row"><span class="gc-k">Elev:</span><span class="gc-v" id="gc-elev">—</span></div>
-      <div class="gc-row"><span class="gc-k"># Sats:</span><span class="gc-v" id="gc-sats">—</span></div>
-      <div class="gc-row"><span class="gc-k">HDOP:</span><span class="gc-v" id="gc-hdop">—</span></div>
-      <div class="gc-row"><span class="gc-k">Fix:</span><span class="gc-v" id="gc-fix">—</span></div>
-      <div class="gc-row"><span class="gc-k">Age:</span><span class="gc-v" id="gc-age">—</span></div>
-      <div class="gc-rule"></div>
-      <div class="gc-row"><span class="gc-k">Heading:</span><span class="gc-v" id="gc-hdg">—</span></div>
-      <div class="gc-row"><span class="gc-k">IMU Roll:</span><span class="gc-v" id="gc-roll">—</span></div>
-      <div class="gc-row"><span class="gc-k">FPS:</span><span class="gc-v" id="gc-fps">—</span></div>
+    <span class="sb-spacer"></span>
+    <!-- Right group: play/pause immediately left of the rotating info it controls, then
+         the Fix/RTK + rotating info; the fullscreen toggle stays at the far right. -->
+    <button id="sb-pause" title="Pause / resume rotating field info">❚❚</button>
+    <div class="sb-left">
+      <div class="sb-row1">
+        <button id="sb-fixbtn" title="GPS detail">
+          <span id="sb-fixdot" class="dot"></span>
+          <span id="sb-fix">—</span>
+        </button>
+        <span id="sb-age" class="sb-sec"></span>
+      </div>
+      <div id="sb-rot" class="sb-rot">—</div>
+      <!-- GPS-detail card (Phase 5): toggled by the fix dot. Nested in .sb-left so it
+           anchors under the fix readout now that the readout lives on the right. -->
+      <div id="sb-gpscard">
+        <div class="gc-ll" id="gc-lat">—</div>
+        <div class="gc-ll" id="gc-lon">—</div>
+        <div class="gc-rule"></div>
+        <div class="gc-row"><span class="gc-k">Elev:</span><span class="gc-v" id="gc-elev">—</span></div>
+        <div class="gc-row"><span class="gc-k"># Sats:</span><span class="gc-v" id="gc-sats">—</span></div>
+        <div class="gc-row"><span class="gc-k">HDOP:</span><span class="gc-v" id="gc-hdop">—</span></div>
+        <div class="gc-row"><span class="gc-k">Fix:</span><span class="gc-v" id="gc-fix">—</span></div>
+        <div class="gc-row"><span class="gc-k">Age:</span><span class="gc-v" id="gc-age">—</span></div>
+        <div class="gc-rule"></div>
+        <div class="gc-row"><span class="gc-k">Heading:</span><span class="gc-v" id="gc-hdg">—</span></div>
+        <div class="gc-row"><span class="gc-k">IMU Roll:</span><span class="gc-v" id="gc-roll">—</span></div>
+        <div class="gc-row"><span class="gc-k">FPS:</span><span class="gc-v" id="gc-fps">—</span></div>
+      </div>
     </div>
+    <button id="sb-fs" title="Fullscreen (hide browser bars)">⛶</button>
   </div>
   <div id="lb"></div>
   <div id="headland-hud"></div>

--- a/sys/version.h
+++ b/sys/version.h
@@ -5,7 +5,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 6
-#define VERSION_PATCH 54
+#define VERSION_PATCH 55
 
-#define VERSION "26.6.54"
+#define VERSION "26.6.55"
 #define VERSION_DATE "2026-06-28"


### PR DESCRIPTION
## Problem

On a tablet in fullscreen, the OS draws an exit **"✕" pill** at the top-left (e.g. iPad Safari's Fullscreen-API control). A web page **cannot hide it or draw over it** — it's composited above the page. It was landing on the RTK fix readout, the rotating info field, and the pause toggle, so you'd hit the X instead of the control.

## Change

Lay the status bar out so the pill only ever sits beside something **non-tappable**:

- **Swap the groups** — left is now the non-interactive **Operator indicator**, then Modules / Speed / Heading; everything tappable is well to its right.
- **Right group:** play/pause immediately left of the rotating info it controls (it was isolated on the far left, unclear what it did), then the **Fix/RTK + rotating info**, then the fullscreen toggle at the far right.
- **Nudge the Operator indicator 75px right while fullscreen** (`body.fs-on`, toggled on `fullscreenchange`) so the pill clears it and it stays readable. **Windowed layout is unaffected.**
- **Nest the GPS-detail card** under the fix readout so it follows it to the right instead of popping up on the far left.

Device-verified on iPad (headless host on macOS) — the pill clears the Operator dot and nothing tappable is near it.

## Also in this PR (separate commit): host version logging

Diagnosing a stale daemon deploy was hard because the `[headless] ready` line carried no version and the .NET `<Version>` was pinned at `26.6.1` (never tracked `sys/version.h`) — two builds reported the same number. Now the headless host prints `AssemblyInformationalVersion` (version + embedded git hash) on startup, and `<Version>` is synced to `26.6.55`, so the journal shows exactly which build is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)