### PR TITLE
Fixes an Android startup crash caused by an invalid foreground service notification. (issue #28)

### DIFF
--- a/Platforms/AgOpenWeb.Android/BackendService.cs
+++ b/Platforms/AgOpenWeb.Android/BackendService.cs
@@ -124,7 +124,6 @@ internal sealed class BackendService : Service
             : new Notification.Builder(this);
         builder.SetContentTitle("AgOpenWeb")
             .SetContentText("Guidance host running — open the app or browse to this device on :5174")
-            //.SetSmallIcon(ApplicationInfo?.Icon ?? global::Android.Resource.Drawable.IcDialogInfo)
             .SetSmallIcon(Resource.Drawable.ic_start_agopenweb)
             .SetCategory(Notification.CategoryService)
             .SetOngoing(true);

--- a/Platforms/AgOpenWeb.Android/BackendService.cs
+++ b/Platforms/AgOpenWeb.Android/BackendService.cs
@@ -124,7 +124,9 @@ internal sealed class BackendService : Service
             : new Notification.Builder(this);
         builder.SetContentTitle("AgOpenWeb")
             .SetContentText("Guidance host running — open the app or browse to this device on :5174")
-            .SetSmallIcon(ApplicationInfo?.Icon ?? global::Android.Resource.Drawable.IcDialogInfo)
+            //.SetSmallIcon(ApplicationInfo?.Icon ?? global::Android.Resource.Drawable.IcDialogInfo)
+            .SetSmallIcon(Resource.Drawable.ic_start_agopenweb)
+            .SetCategory(Notification.CategoryService)
             .SetOngoing(true);
         return builder.Build();
     }

--- a/Platforms/AgOpenWeb.Android/Resources/drawable/ic_start_agopenweb.xml
+++ b/Platforms/AgOpenWeb.Android/Resources/drawable/ic_start_agopenweb.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M12,2 L21,11 L16.5,11 L16.5,21 L7.5,11 L3,11 Z" />
+</vector>


### PR DESCRIPTION
## What changed

Fixes an Android startup crash caused by an invalid foreground service notification.

The backend service previously used the application launcher icon as the notification small icon. On some Android versions this caused `StartForeground()` to fail with:

`android.app.RemoteServiceException: CannotPostForegroundServiceNotificationException: Bad notification for startForeground`

This PR:
- Replaces the notification small icon with a dedicated notification drawable.
- Marks the notification with `Notification.CategoryService`.
- Adds a dedicated vector drawable (`ic_start_agopenweb.xml`) for the foreground service notification.

## Related issue

Closes #28

## Pre-submit checklist

- [x] `dotnet build` succeeds with no errors
- [x] `dotnet test` passes
- [x] Tested on: Android

## Screenshots

Not applicable (no UI changes).