### PR TITLE
Diagnostics status line: marker-gated FPS / LINK / CTRL readout

### DIFF
--- a/Shared/AgOpenWeb.RemoteServer/Contracts.cs
+++ b/Shared/AgOpenWeb.RemoteServer/Contracts.cs
@@ -243,7 +243,12 @@ public record StatusDto(
     // "coverage painted with no open job" prompt (DialogType.UnsavedCoverage). The web client
     // renders its own Save/Discard/Cancel prompt off this flag — without it the host opens a
     // dialog nothing renders and the close hangs. Message text is static (client owns it).
-    bool UnsavedCoveragePrompt);
+    bool UnsavedCoveragePrompt,
+    // Dev diagnostics row (marker-gated by .show_dev_overlay): DevOverlay reveals the status
+    // bar's taller diagnostics line; GpsToPgnLatencyMs is the host control-loop latency
+    // (GPS receive → PGN send, ms) shown there beside the client FPS + transport age.
+    bool DevOverlay,
+    double GpsToPgnLatencyMs);
 
 /// <summary>Config read-frame (Phase 9). A structured projection of
 /// ConfigurationStore for the left-nav settings panels — seeded on connect and

--- a/Shared/AgOpenWeb.RemoteServer/SceneProjector.cs
+++ b/Shared/AgOpenWeb.RemoteServer/SceneProjector.cs
@@ -28,6 +28,8 @@ public sealed class SceneProjector
     private readonly ISettingsService _settings;
     private readonly IVehicleProfileService _vehicleProfiles;
     private readonly IPersistentStateService _persist;
+    // Dev diagnostics overlay gate — read once from the .show_dev_overlay marker file.
+    private readonly bool _devOverlay = DevOverlayMarker.IsEnabled();
 
     /// <summary>Host-supplied projector for the Field Builder Headland-tab segment list.
     /// The segments live on the VM (MainViewModel.HeadlandSegments) — there is no
@@ -367,7 +369,11 @@ public sealed class SceneProjector
             // Field Tools — Offset Fix drift offset (meters).
             _state.Field.DriftEasting,
             _state.Field.DriftNorthing,
-            _state.UI.IsUnsavedCoverageDialogVisible);
+            _state.UI.IsUnsavedCoverageDialogVisible,
+            // Dev diagnostics row: overlay gate (marker) + host control-loop latency (same
+            // VehicleStateSnapshot.TotalLatencyMs the VM's GpsToPgnLatencyMs mirrors).
+            _devOverlay,
+            _autoSteer.LatestSnapshot?.TotalLatencyMs ?? 0.0);
     }
 
     // NTRIP profiles read-frame (Network IO). Projects INtripProfileService's saved

--- a/Shared/AgOpenWeb.RemoteServer/WebSocketHub.cs
+++ b/Shared/AgOpenWeb.RemoteServer/WebSocketHub.cs
@@ -106,6 +106,13 @@ public sealed class WebSocketHub
             case "control.acquire": _authority.Acquire(conn, arg); return;
             case "control.release": _authority.Release(conn); return;
             case "control.presence": _authority.Refresh(conn); return;
+            // Link-latency probe: reply immediately on this connection (here, on the
+            // receive-loop thread — no UI-thread hop) so the client's RTT measures the
+            // pure server↔client link, not host scheduling.
+            case "diag.ping":
+                if (_clients.TryGetValue(conn, out var pinger))
+                    _ = SendToAsync(pinger, WireCodec.EncodePong(arg), CancellationToken.None);
+                return;
         }
 
         if (IsRestrictedCommand is { } restricted && restricted(id) && !_authority.HoldsFresh(conn))

--- a/Shared/AgOpenWeb.RemoteServer/WireCodec.cs
+++ b/Shared/AgOpenWeb.RemoteServer/WireCodec.cs
@@ -19,7 +19,7 @@ public static class WireCodec
     public const byte Scene = 1, Tick = 2, CoverageInit = 3, CoverageCells = 4, Status = 5,
         ControlState = 6, Hello = 7, Config = 8, Profiles = 9, Wizard = 10, NtripProfiles = 11,
         FieldOps = 12, AgShare = 13, AppInfo = 14, FieldTools = 15, RecordedPath = 16, Boundary = 17,
-        Sound = 18;
+        Sound = 18, Pong = 19;
 
     /// <summary>One-shot alert: tells the client to play sound effect
     /// <paramref name="effectId"/> (the <c>SoundEffect</c> enum value). Pushed
@@ -578,6 +578,20 @@ public static class WireCodec
         w.Write((float)s.DriftNorthing);
         // Unsaved-coverage guard prompt (append-only).
         w.Write((byte)(s.UnsavedCoveragePrompt ? 1 : 0));
+        // Dev diagnostics row (append-only): overlay gate + host control-loop latency.
+        w.Write((byte)(s.DevOverlay ? 1 : 0));
+        w.Write((float)s.GpsToPgnLatencyMs);
+        return ms.ToArray();
+    }
+
+    // Round-trip link-latency reply. Echoes the client's token (its performance.now()
+    // timestamp) verbatim so the client computes RTT = now − token on its own clock.
+    public static byte[] EncodePong(string token)
+    {
+        using var ms = new MemoryStream();
+        using var w = new BinaryWriter(ms);
+        w.Write(Pong);
+        WriteStr(w, token);
         return ms.ToArray();
     }
 

--- a/Shared/AgOpenWeb.RemoteServer/wwwroot/app.js
+++ b/Shared/AgOpenWeb.RemoteServer/wwwroot/app.js
@@ -81,6 +81,8 @@ let wizard = null;     // Steer Wizard frame (host-driven); null when not open
 let wizardDirty = false;
 let fps = 0;           // smoothed client render rate (for the GPS-detail card)
 let _fpsFrames = 0, _fpsT0 = 0;
+let _diagT0 = 0;       // throttle (~4 Hz) for the marker-gated diag line's DOM writes
+let linkRttMs = null;  // EMA of server↔client round-trip (ms), from diag.ping/PONG
 // Remote actuation authority (Phase 2 safety layer): our connection id (from the
 // Hello frame), the latest broadcast control state, and whether we hold control.
 let myClientId = null;
@@ -280,6 +282,12 @@ const transport = RemoteTransport.create({
   onHello(id) { myClientId = id; updateControlUi(); claimSeatIfFree(); applyMobileQualityCap(); },
   onControlState(s) { lastControl = s; updateControlUi(); claimSeatIfFree(); },
   onSound(id) { Sounds.play(id); },
+  // Round-trip link probe reply: token is the performance.now() we sent in diag.ping, so
+  // RTT = now − token measures the pure server↔client link (one client clock, no skew).
+  onPong(token) {
+    const rtt = performance.now() - parseFloat(token);
+    if (rtt >= 0 && rtt < 60000) linkRttMs = (linkRttMs === null) ? rtt : linkRttMs + 0.3 * (rtt - linkRttMs);
+  },
   onStatus(s) { connState = s; renderRole(); claimSeatIfFree(); },
 });
 
@@ -3328,6 +3336,10 @@ const SB = {
   gcHdop: document.getElementById('gc-hdop'), gcFix: document.getElementById('gc-fix'),
   gcAge: document.getElementById('gc-age'), gcHdg: document.getElementById('gc-hdg'),
   gcRoll: document.getElementById('gc-roll'), gcFps: document.getElementById('gc-fps'),
+  // Dev diagnostics line (marker-gated by .show_dev_overlay).
+  diagRow: document.getElementById('sb-diag'),
+  sbdFps: document.getElementById('sbd-fps'), sbdLink: document.getElementById('sbd-link'),
+  sbdCtrl: document.getElementById('sbd-ctrl'),
 };
 // GPS fix-quality → dot colour (matches the native FixQualityToColor intent).
 function fixColor(q) {
@@ -3456,7 +3468,7 @@ addEventListener('pointerdown', () => {
 
 function renderStatusBar() {
   const s = statusBar;
-  if (!s) { SB.bar.style.display = 'none'; return; }
+  if (!s) { SB.bar.style.display = 'none'; if (SB.diagRow) SB.diagRow.style.display = 'none'; return; }
   SB.bar.style.display = 'flex';
   SB.fixDot.style.background = fixColor(s.fixQuality);
   SB.fix.textContent = s.fixText || '—';
@@ -3489,6 +3501,24 @@ function renderStatusBar() {
     SB.gcHdg.textContent = hdgDeg != null ? (((hdgDeg % 360) + 360) % 360).toFixed(1) + '°' : '—';
     SB.gcRoll.textContent = (tick && typeof tick.roll === 'number') ? tick.roll.toFixed(1) + '°' : '—';
     SB.gcFps.textContent = fps.toFixed(0);
+  }
+  // Dev diagnostics line (marker-gated). DOM text only — no canvas overlay — so reading FPS
+  // doesn't perturb the frame loop (an overlay/dialog did, hence the status-line approach).
+  // Throttled to ~4 Hz; that tick also fires the link probe. FPS = client render rate; LINK =
+  // server↔client round-trip (ms, from diag.ping/PONG); CTRL = backend→AiO control-loop
+  // latency (GPS receive → PGN send, ms).
+  if (s.devOverlay) {
+    if (SB.diagRow.style.display !== 'flex') SB.diagRow.style.display = 'flex';
+    const nowMs = performance.now();
+    if (nowMs - _diagT0 >= 250) {
+      _diagT0 = nowMs;
+      transport.send('diag.ping|' + nowMs); // link probe; the PONG reply updates linkRttMs
+      SB.sbdFps.textContent = fps.toFixed(0);
+      SB.sbdLink.textContent = linkRttMs != null ? linkRttMs.toFixed(1) + ' ms' : '—';
+      SB.sbdCtrl.textContent = (s.gpsToPgnLatencyMs || 0).toFixed(1) + ' ms';
+    }
+  } else if (SB.diagRow.style.display !== 'none') {
+    SB.diagRow.style.display = 'none';
   }
 }
 // Heading in AgOpen 000.0° form (constant width). Input degrees, any sign.

--- a/Shared/AgOpenWeb.RemoteServer/wwwroot/index.html
+++ b/Shared/AgOpenWeb.RemoteServer/wwwroot/index.html
@@ -79,6 +79,15 @@
       color: var(--text-2); font: 600 15px system-ui, sans-serif;
       user-select: none; -webkit-user-select: none;
     }
+    #sb-diag {
+      position: fixed; top: calc(var(--sat) + 46px); left: 0; right: 0; height: 26px; display: none;
+      align-items: center; gap: 22px; padding: 0 14px 0 69px; box-sizing: border-box;
+      background: var(--float-bg); border-bottom: 1px solid var(--border-2);
+      color: var(--text-muted); font: 600 12px ui-monospace, SFMono-Regular, Menlo, monospace;
+      user-select: none; -webkit-user-select: none;
+    }
+    #sb-diag .sbd-k { color: var(--text-muted); margin-right: 6px; letter-spacing: 0.04em; }
+    #sb-diag .sbd-v { color: var(--text-2); font-variant-numeric: tabular-nums; }
     #statusbar button { background: transparent; border: 0; color: inherit; cursor: pointer;
       font: inherit; padding: 2px 6px; display: inline-flex; align-items: center; gap: 6px; }
     #statusbar button:hover { background: rgba(var(--ov),0.06); border-radius: 6px; }
@@ -1056,6 +1065,15 @@
       </div>
     </div>
     <button id="sb-fs" title="Fullscreen (hide browser bars)">⛶</button>
+  </div>
+  <!-- Dev diagnostics line (marker-gated by .show_dev_overlay): a second bar stacked under the
+       status bar. FPS = client render rate; LINK = true server↔client round-trip latency
+       (diag.ping/PONG); CTRL = backend→AiO control-loop latency (GPS→PGN). Kept as DOM text
+       (not a canvas overlay) so monitoring FPS doesn't itself cost FPS. -->
+  <div id="sb-diag">
+    <span class="sbd-item"><span class="sbd-k">FPS</span><span class="sbd-v" id="sbd-fps">—</span></span>
+    <span class="sbd-item"><span class="sbd-k">LINK</span><span class="sbd-v" id="sbd-link">—</span></span>
+    <span class="sbd-item"><span class="sbd-k">CTRL</span><span class="sbd-v" id="sbd-ctrl">—</span></span>
   </div>
   <div id="lb"></div>
   <div id="headland-hud"></div>

--- a/Shared/AgOpenWeb.RemoteServer/wwwroot/transport.js
+++ b/Shared/AgOpenWeb.RemoteServer/wwwroot/transport.js
@@ -24,7 +24,7 @@ window.RemoteTransport = {
     const url = `${proto}//${location.host}/ws`;
     let ws = null, stopped = false;
 
-    const TYPE = { SCENE: 1, TICK: 2, COVERAGE_INIT: 3, COVERAGE_CELLS: 4, STATUS: 5, CONTROL_STATE: 6, HELLO: 7, CONFIG: 8, PROFILES: 9, WIZARD: 10, NTRIP_PROFILES: 11, FIELD_OPS: 12, AGSHARE: 13, APP_INFO: 14, FIELD_TOOLS: 15, RECORDED_PATH: 16, BOUNDARY: 17, SOUND: 18 };
+    const TYPE = { SCENE: 1, TICK: 2, COVERAGE_INIT: 3, COVERAGE_CELLS: 4, STATUS: 5, CONTROL_STATE: 6, HELLO: 7, CONFIG: 8, PROFILES: 9, WIZARD: 10, NTRIP_PROFILES: 11, FIELD_OPS: 12, AGSHARE: 13, APP_INFO: 14, FIELD_TOOLS: 15, RECORDED_PATH: 16, BOUNDARY: 17, SOUND: 18, PONG: 19 };
     const td = new TextDecoder();
 
     function decode(buffer) {
@@ -134,6 +134,8 @@ window.RemoteTransport = {
           const simPanelVisible = !!u8();
           const driftEasting = f32(), driftNorthing = f32();
           const unsavedCoveragePrompt = !!u8();
+          // Dev diagnostics row (append-only): overlay gate + host control-loop latency (ms).
+          const devOverlay = !!u8(), gpsToPgnLatencyMs = f32();
           handlers.onStatusBar && handlers.onStatusBar({
             fixQuality, fixText, age, sats, isMetric,
             gpsOk, imuOk, autoSteerOk, machineOk, imuIp, autoSteerIp, machineIp,
@@ -144,6 +146,7 @@ window.RemoteTransport = {
             swCollecting, swSamples, swMean, swMedian, swStdDev, swOffsetDeg, swConfidence, swValid,
             gpsIp, moduleSubnet, hostIps, ntripConnected, ntripStatus, ntripBytes, ntripTestStatus,
             simPanelVisible, driftEasting, driftNorthing, unsavedCoveragePrompt,
+            devOverlay, gpsToPgnLatencyMs,
           });
           break;
         }
@@ -335,6 +338,13 @@ window.RemoteTransport = {
           // One-shot alert: payload is a single SoundEffect id. The host already
           // applied the per-sound config gating; the client just plays it.
           handlers.onSound && handlers.onSound(u8());
+          break;
+        }
+        case TYPE.PONG: {
+          // Link-latency probe reply: echoes the token (client perf.now()) we sent in
+          // diag.ping. RTT = now − token, measured on the one client clock.
+          const token = str();
+          handlers.onPong && handlers.onPong(token);
           break;
         }
       }

--- a/sys/version.h
+++ b/sys/version.h
@@ -5,7 +5,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 6
-#define VERSION_PATCH 57
+#define VERSION_PATCH 58
 
-#define VERSION "26.6.57"
-#define VERSION_DATE "2026-06-29"
+#define VERSION "26.6.58"
+#define VERSION_DATE "2026-06-30"


### PR DESCRIPTION
## What

Restores the dev **diagnostics readout** (FPS + latency) that was orphaned in the web-UI migration, as a **second, marker-gated row** stacked directly under the status bar.

It's deliberately **DOM text, not a canvas overlay** — an overlay/dialog perturbs the CanvasKit render loop, so monitoring FPS would itself cost FPS. The status-line approach is observer-effect-free.

## Readouts

| | Meaning |
|---|---|
| **FPS** | Client render rate (already computed; now always visible, not just in the GPS card) |
| **LINK** | **True** server↔client round-trip latency. Client sends `diag.ping\|<perf.now()>` (~4 Hz, only while the overlay is on); `WebSocketHub` answers it **inline in `Dispatch` on the receive-loop thread** (no UI-thread hop), echoing the token; the client computes RTT on its own clock (no clock-sync, no skew). EMA-smoothed. |
| **CTRL** | Backend→AiO control-loop latency (`GpsToPgnLatencyMs`, GPS receive → PGN send) — the same `VehicleStateSnapshot.TotalLatencyMs` the VM mirrors; the sub-ms number the old native overlay showed. |

## Gating

Shown only when `<Documents>/AgOpenWeb/.show_dev_overlay` exists (the existing `DevOverlayMarker`, read once at startup), projected to the client via a new `StatusDto.DevOverlay` flag. Delete the marker + restart to hide.

## Wire compatibility

Additive only — `StatusDto` gains two append-only fields, and a new `Pong = 19` message type. Older clients are unaffected.

## Test

- Desktop build green.
- Create the marker, run the headless host, browse from a client: the diag row appears under the status bar with live FPS / LINK / CTRL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)