### PR TITLE
Coverage: smoother worked-area edges (bilinear blit + alpha-AA)

### DIFF
--- a/Shared/AgOpenWeb.RemoteServer/CoverageProjector.cs
+++ b/Shared/AgOpenWeb.RemoteServer/CoverageProjector.cs
@@ -36,7 +36,7 @@ public sealed class CoverageProjector
             return null;
         var flat = new List<int>();
         foreach (var (x, y, c) in _cov.GetCoverageBitmapCells(dim.CellSize, bnd.MinE, bnd.MaxE, bnd.MinN, bnd.MaxN))
-            Add(flat, x, y, c);
+            Add(flat, x, y, c, _cov.GetDisplayCellAlpha255(x, y));
         return flat.Count == 0 ? null : new CoverageCellsDto(flat.ToArray());
     }
 
@@ -62,7 +62,7 @@ public sealed class CoverageProjector
             long idx = (long)y * _w + x;
             if (_sent[idx]) continue;
             _sent[idx] = true;
-            Add(flat, x, y, c);
+            Add(flat, x, y, c, _cov.GetDisplayCellAlpha255(x, y));
         }
         return flat.Count == 0 ? null : new CoverageCellsDto(flat.ToArray());
     }
@@ -78,7 +78,7 @@ public sealed class CoverageProjector
         if (_cov.DisplayDimensions is not { } dim) return null;
         var flat = new List<int>();
         foreach (var (x, y, c) in _cov.GetNewCoverageBitmapCellsServer(dim.CellSize))
-            Add(flat, x, y, c);
+            Add(flat, x, y, c, _cov.GetDisplayCellAlpha255(x, y));
         return flat.Count == 0 ? null : new CoverageCellsDto(flat.ToArray());
     }
 
@@ -93,10 +93,12 @@ public sealed class CoverageProjector
     /// <summary>Forget what's been sent (on bounds/cell-size change → clients re-init).</summary>
     public void ResetSent() => _sent = null;
 
-    private static void Add(List<int> flat, int x, int y, CoverageColor c)
+    // Pack alpha into the high byte: the client reads (a<<24)|(r<<16)|(g<<8)|b. Alpha is the
+    // display cell's coverage fraction (255 = full/interior) so edge cells render feathered.
+    private static void Add(List<int> flat, int x, int y, CoverageColor c, int a)
     {
         flat.Add(x);
         flat.Add(y);
-        flat.Add((c.R << 16) | (c.G << 8) | c.B);
+        flat.Add((a << 24) | (c.R << 16) | (c.G << 8) | c.B);
     }
 }

--- a/Shared/AgOpenWeb.RemoteServer/wwwroot/app.js
+++ b/Shared/AgOpenWeb.RemoteServer/wwwroot/app.js
@@ -243,6 +243,10 @@ const transport = RemoteTransport.create({
     if (surface) {
       surface.getCanvas().clear(CK.TRANSPARENT);
       covPaint = new CK.Paint(); covPaint.setStyle(CK.PaintStyle.Fill); covPaint.setAntiAlias(false);
+      // Src (replace), not SrcOver: cells carry a coverage-fraction alpha (edge cells < 1),
+      // and a cell is re-emitted with rising alpha as it fills — replace sets the exact value
+      // each time; SrcOver would blend re-draws and creep edges toward opaque.
+      covPaint.setBlendMode(CK.BlendMode.Src);
     } else {
       canvas = document.createElement('canvas'); canvas.width = w; canvas.height = h; cctx = canvas.getContext('2d');
     }
@@ -4502,7 +4506,7 @@ function drawImagerySk(canvas) {
 // (top row = high northing) is placed via a px→world affine, then perspM warps it
 // — Skia does perspective-correct sampling AND near-plane clipping on the GPU, so
 // it stays correct even when part of the rect falls behind the tilted camera.
-function drawImageWorldSk(canvas, img, minE, minN, maxE, maxN, filter) {
+function drawImageWorldSk(canvas, img, minE, minN, maxE, maxN, filter, mipMode) {
   const w = img.width(), h = img.height();
   // Map image px → CAMERA-RELATIVE world (minE-camE …): the world−camera offset is done
   // here in f64 so only small coords reach the f32 matrix — no floating-origin jitter on
@@ -4510,9 +4514,11 @@ function drawImageWorldSk(canvas, img, minE, minN, maxE, maxN, filter) {
   const imgToWorld = [(maxE - minE) / w, 0, minE - camE, 0, -(maxN - minN) / h, maxN - camN, 0, 0, 1];
   // Photo layers (imagery / satellite tiles, Linear filter) recede to the horizon
   // under perspective → heavy minification → shimmer/crawl under motion without a
-  // mip chain. Trilinear mipmaps fix it (matches native's mipmapped imagery). But
-  // Nearest callers (coverage cells = data) must stay crisp — no mipmaps for them.
-  const mip = (filter === CK.FilterMode.Linear) ? CK.MipmapMode.Linear : CK.MipmapMode.None;
+  // mip chain. Trilinear mipmaps fix it (matches native's mipmapped imagery). Callers
+  // may override the mip mode: coverage uses Linear sampling but mip-free, so its edges
+  // smooth (bilinear) without paying the per-update mip-regen on a multi-MP texture.
+  const mip = (mipMode !== undefined) ? mipMode
+    : ((filter === CK.FilterMode.Linear) ? CK.MipmapMode.Linear : CK.MipmapMode.None);
   canvas.save();
   canvas.concat(perspM);
   canvas.concat(imgToWorld);
@@ -4592,9 +4598,10 @@ function drawSatelliteSk(canvas) {
   }
 }
 // Coverage offscreen → SkImage, re-snapshotted only when the cell grid changed
-// (cov.dirty). Nearest filtering = the 2D path's imageSmoothingEnabled=false, so
-// cells stay crisp instead of blurring when zoomed in. The snapshot lives on the
-// cov object so a new coverage-init naturally starts with a fresh (null) image.
+// (cov.dirty). The world blit uses Linear (bilinear) sampling so the cell-grid edge
+// reads smooth instead of stair-stepped; see the blit call below for the mip-free
+// rationale. The snapshot lives on the cov object so a new coverage-init naturally
+// starts with a fresh (null) image.
 // Fallback-path throttle (2D canvas → full re-upload): cap the expensive whole-texture
 // rebuild at ~4 Hz. The GPU render-target path below has no such cost.
 const COV_REBUILD_MS = 250;
@@ -4614,8 +4621,8 @@ function drawCoverageSk(canvas) {
         if (batch.t > cutoff) break;
         const c = batch.cells;
         for (let i = 0; i + 2 < c.length; i += 3) {
-          const x = c[i], y = c[i + 1], rgb = c[i + 2] >>> 0 & 0xFFFFFF;
-          if (rgb !== lastRgb) { paint.setColor(CK.Color((rgb >> 16) & 0xFF, (rgb >> 8) & 0xFF, rgb & 0xFF, 1)); lastRgb = rgb; }
+          const x = c[i], y = c[i + 1], v = c[i + 2] >>> 0; // (a<<24)|(r<<16)|(g<<8)|b
+          if (v !== lastRgb) { paint.setColor(CK.Color((v >> 16) & 0xFF, (v >> 8) & 0xFF, v & 0xFF, ((v >>> 24) & 0xFF) / 255)); lastRgb = v; }
           sk.drawRect(CK.XYWHRect(x, H - 1 - y, 1, 1), paint); // flip: high northing at top
           covCells++;
         }
@@ -4640,8 +4647,14 @@ function drawCoverageSk(canvas) {
         if (batch.t > cutoff) break;
         const c = batch.cells;
         for (let i = 0; i + 2 < c.length; i += 3) {
-          const x = c[i], y = c[i + 1], rgb = c[i + 2];
-          if (rgb !== lastRgb) { cctx.fillStyle = '#' + (rgb >>> 0 & 0xFFFFFF).toString(16).padStart(6, '0'); lastRgb = rgb; }
+          const x = c[i], y = c[i + 1], v = c[i + 2] >>> 0; // (a<<24)|(r<<16)|(g<<8)|b
+          if (v !== lastRgb) {
+            cctx.fillStyle = 'rgba(' + ((v >> 16) & 0xFF) + ',' + ((v >> 8) & 0xFF) + ',' + (v & 0xFF) + ',' + (((v >>> 24) & 0xFF) / 255) + ')';
+            lastRgb = v;
+          }
+          // clear+fill = replace (the 2D analogue of BlendMode.Src) so re-emitted edge
+          // cells set their exact alpha instead of blending toward opaque.
+          cctx.clearRect(x, H - 1 - y, 1, 1);
           cctx.fillRect(x, H - 1 - y, 1, 1); // flip: high northing at offscreen top
           covCells++;
         }
@@ -4661,7 +4674,10 @@ function drawCoverageSk(canvas) {
   const cs = cov.cellSize;
   const minE = cov.originE, minN = cov.originN;
   const maxE = cov.originE + cov.width * cs, maxN = cov.originN + cov.height * cs;
-  drawImageWorldSk(canvas, cov.skImg, minE, minN, maxE, maxN, CK.FilterMode.Nearest);
+  // Bilinear (Linear), mip-free: smooths the cell-grid stair-step at the worked-area edge
+  // without the per-update mip-regen cost. The surface is cleared to premultiplied
+  // TRANSPARENT, so the boundary fades cleanly to transparent (no dark fringe).
+  drawImageWorldSk(canvas, cov.skImg, minE, minN, maxE, maxN, CK.FilterMode.Linear, CK.MipmapMode.None);
 }
 // Tool/section footprint — section bars perpendicular to the (dead-reckoned) tool
 // heading, coloured by ColorCode. Same geometry as the 2D toolFootprint().

--- a/Shared/AgOpenWeb.Services/Coverage/CoverageMapService.cs
+++ b/Shared/AgOpenWeb.Services/Coverage/CoverageMapService.cs
@@ -687,6 +687,34 @@ public class CoverageMapService : ICoverageMapService
     }
 
     /// <summary>
+    /// Coverage fraction (0..255) of a display cell: the share of its underlying 0.1 m
+    /// detection cells that are covered. 255 = fully covered (interior, opaque); a partial
+    /// value is an edge cell the client draws with that alpha, so the boundary feathers
+    /// instead of stair-stepping. Reads detection bits lock-free (same as the emit scans);
+    /// a race only yields a slightly stale fraction, which is harmless.
+    /// </summary>
+    public int GetDisplayCellAlpha255(int displayX, int displayY)
+    {
+        if (_detectionBits == null || !_fieldBoundsSet) return 255;
+        int span = (int)Math.Round(_displayCellSize / BITMAP_CELL_SIZE);
+        if (span < 1) span = 1;
+        // Display cell's world origin → its first underlying detection cell.
+        int ce0 = (int)Math.Floor((_fieldMinE + displayX * _displayCellSize) / BITMAP_CELL_SIZE);
+        int cn0 = (int)Math.Floor((_fieldMinN + displayY * _displayCellSize) / BITMAP_CELL_SIZE);
+        int covered = 0, total = span * span;
+        for (int j = 0; j < span; j++)
+            for (int i = 0; i < span; i++)
+                if (IsCellCovered(ce0 + i, cn0 + j)) covered++;
+        // Near-full cells snap to opaque: the rasterizer center-samples, so interior cells
+        // occasionally miss a stray detection cell at quad seams. A literal fraction would
+        // let the (often dark) map fleck through those — the old binary "any → opaque" rule
+        // hid it. Only cells well below FULL (genuine worked-area edge) feather.
+        const double FULL = 0.75;
+        double frac = (double)covered / total;
+        return frac >= FULL ? 255 : (int)(frac / FULL * 255.0);
+    }
+
+    /// <summary>
     /// Mark a rectangular area as covered. Useful for tests that need pre-applied coverage
     /// without driving through the area.
     /// </summary>

--- a/Shared/AgOpenWeb.Services/Interfaces/ICoverageMapService.cs
+++ b/Shared/AgOpenWeb.Services/Interfaces/ICoverageMapService.cs
@@ -169,6 +169,15 @@ public interface ICoverageMapService
     IEnumerable<(int CellX, int CellY, CoverageColor Color)> GetNewCoverageBitmapCellsServer(double cellSize);
 
     /// <summary>
+    /// Coverage fraction (0..255) of a DISPLAY cell — the share of its underlying 0.1 m
+    /// detection cells that are covered. 255 = fully covered (interior); a partial value
+    /// marks an edge cell, which the client renders as a soft alpha so the worked-area
+    /// boundary feathers instead of stair-stepping. Coords are display-cell coords (same
+    /// space as GetCoverageBitmapCells output).
+    /// </summary>
+    int GetDisplayCellAlpha255(int displayX, int displayY);
+
+    /// <summary>
     /// Get patches for a specific zone
     /// </summary>
     /// <param name="zoneIndex">Zone index (0-based)</param>

--- a/sys/version.h
+++ b/sys/version.h
@@ -5,7 +5,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 6
-#define VERSION_PATCH 58
+#define VERSION_PATCH 59
 
-#define VERSION "26.6.58"
+#define VERSION "26.6.59"
 #define VERSION_DATE "2026-06-30"


### PR DESCRIPTION
## What

Makes the coverage (worked-area) boundary read **smooth** instead of stair-stepped at the cell grid — **no measurable FPS cost** (iPad held 40–43 FPS, baseline ~40).

Two stacked changes:

### 1. Bilinear blit
`drawImageWorldSk` gains an explicit mip-mode override; the coverage blit switches `Nearest` → `Linear` + `MipmapMode.None`. The cell texture is now bilinearly sampled (edges smooth) without paying the per-update trilinear mip-regen on a multi-megapixel texture. Imagery's mipmaps are untouched.

### 2. Alpha-AA from the detection grid
Each display cell gets a coverage-fraction **alpha** derived from the 0.1 m detection bits we already keep (`GetDisplayCellAlpha255`): interior = opaque, edge cells = partial, so the boundary feathers into the background. **Stays a single O(1) blit.**

- Alpha rides in the **high byte** of the existing cell int — no wire-format change.
- Client draws cells with **`BlendMode.Src`** (replace) so a cell re-emitted with rising alpha as it fills sets its exact value instead of blending toward opaque.
- Near-full cells (≥75%) snap to opaque so rasterizer micro-gaps at quad seams don't let the (dark) map fleck through interior coverage.

## Scope / trade-off

On large fields the display cell is coarse (0.5 m at 100 ha), so this is a **soft feather**, not a razor-crisp vector edge. A true vector edge would mean re-introducing per-frame swath geometry (the cell-based-display decision made for mobile perf) — deferred unless the feather proves insufficient with alpha testers.

## Test

- Desktop build green.
- Verified on physical iPad via the headless host: edges noticeably smoother, FPS unchanged (40–43), no interior flecking after the ≥75% opaque snap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)