### PR TITLE
Coverage: crisp worked-area edge via server-fed vector perimeter

### DIFF
--- a/Shared/AgOpenWeb.RemoteServer/MapBroadcaster.cs
+++ b/Shared/AgOpenWeb.RemoteServer/MapBroadcaster.cs
@@ -35,6 +35,7 @@ public sealed class MapBroadcaster : IAsyncDisposable
     private Task? _loop;
 
     private int _statusTick;
+    private int _perimTick; // throttles the crisp-edge perimeter broadcast to ~2 Hz
     // Set by the host (App.axaml.cs) — projects the live SteerWizardViewModel to a
     // WizardDto, or null when the remote wizard isn't open. Sent every tick while open
     // (the calibration steps need live phase/angle updates).
@@ -243,6 +244,17 @@ public sealed class MapBroadcaster : IAsyncDisposable
                     }
                 }
                 catch { /* tolerate transient coverage-layer races */ }
+
+                // Crisp worked-area edge: the vector perimeter (bounded by perimeter length,
+                // not area). ~2 Hz — it shifts slowly as passes are laid, and the client just
+                // replaces its set. Only once a field/coverage grid exists.
+                if (++_perimTick >= 5)
+                {
+                    _perimTick = 0;
+                    if (_coverageInitSent)
+                        await _ws.BroadcastAsync(WireCodec.EncodeCoverageEdge(_coverage.GetCoveragePerimeter()), ct)
+                            .ConfigureAwait(false);
+                }
 
                 // Status bar changes slowly (fix/age/modules) — send at ~2 Hz, not
                 // every 10 Hz tick. Speed (which updates fast) rides the Tick.

--- a/Shared/AgOpenWeb.RemoteServer/WireCodec.cs
+++ b/Shared/AgOpenWeb.RemoteServer/WireCodec.cs
@@ -19,7 +19,7 @@ public static class WireCodec
     public const byte Scene = 1, Tick = 2, CoverageInit = 3, CoverageCells = 4, Status = 5,
         ControlState = 6, Hello = 7, Config = 8, Profiles = 9, Wizard = 10, NtripProfiles = 11,
         FieldOps = 12, AgShare = 13, AppInfo = 14, FieldTools = 15, RecordedPath = 16, Boundary = 17,
-        Sound = 18, Pong = 19;
+        Sound = 18, Pong = 19, CoverageEdge = 20;
 
     /// <summary>One-shot alert: tells the client to play sound effect
     /// <paramref name="effectId"/> (the <c>SoundEffect</c> enum value). Pushed
@@ -581,6 +581,22 @@ public static class WireCodec
         // Dev diagnostics row (append-only): overlay gate + host control-loop latency.
         w.Write((byte)(s.DevOverlay ? 1 : 0));
         w.Write((float)s.GpsToPgnLatencyMs);
+        return ms.ToArray();
+    }
+
+    // Crisp worked-area edge: the vector perimeter as polylines (field-local metres). Bounded
+    // by perimeter length. [i32 polylineCount][ per polyline: i32 pointCount, f32 e, f32 n … ].
+    public static byte[] EncodeCoverageEdge(IReadOnlyList<IReadOnlyList<AgOpenWeb.Models.Base.Vec2>> polylines)
+    {
+        using var ms = new MemoryStream();
+        using var w = new BinaryWriter(ms);
+        w.Write(CoverageEdge);
+        w.Write(polylines.Count);
+        foreach (var pl in polylines)
+        {
+            w.Write(pl.Count);
+            foreach (var p in pl) { w.Write((float)p.Easting); w.Write((float)p.Northing); }
+        }
         return ms.ToArray();
     }
 

--- a/Shared/AgOpenWeb.RemoteServer/wwwroot/app.js
+++ b/Shared/AgOpenWeb.RemoteServer/wwwroot/app.js
@@ -93,6 +93,9 @@ let iHoldControl = false;
 //      blitted to world space each frame. Snapshot on connect, deltas after. ----
 let cov = null;        // { cellSize, originE, originN, width, height, canvas, cctx }
 let covCells = 0;
+let coverageEdges = null;   // crisp worked-area perimeter polylines (server-fed, field-local m)
+let covEdgeRgb = 0x98fb98;  // last coverage colour seen → the perimeter stroke matches the fill
+const EDGE_OFF = new URLSearchParams(location.search).has('noedge'); // ?noedge → A/B the edge off
 
 // ---- ground texture: the tiled field backdrop. Two variants — a dark (night) and a
 //      light (day) version of the same texture — picked by mapIsDay so the field reads
@@ -268,6 +271,7 @@ const transport = RemoteTransport.create({
     // playback exactly (same socket/latency), so the front now tracks the tool at any speed.
     cov.pending.push({ cells: msg.cells, t: performance.now() });
   },
+  onCoverageEdge(polylines) { coverageEdges = polylines; }, // crisp worked-area perimeter (~2 Hz)
   onStatusBar(s) { statusBar = s; if (typeof applySimBarVisible === 'function') applySimBarVisible(); syncUnsavedCov(); },
   onConfig(c) { config = c; configDirty = true; applyTheme(c && c.display && c.display.isDayMode); },
   onProfiles(p) { profiles = p; profilesDirty = true; },
@@ -4622,7 +4626,7 @@ function drawCoverageSk(canvas) {
         const c = batch.cells;
         for (let i = 0; i + 2 < c.length; i += 3) {
           const x = c[i], y = c[i + 1], v = c[i + 2] >>> 0; // (a<<24)|(r<<16)|(g<<8)|b
-          if (v !== lastRgb) { paint.setColor(CK.Color((v >> 16) & 0xFF, (v >> 8) & 0xFF, v & 0xFF, ((v >>> 24) & 0xFF) / 255)); lastRgb = v; }
+          if (v !== lastRgb) { paint.setColor(CK.Color((v >> 16) & 0xFF, (v >> 8) & 0xFF, v & 0xFF, ((v >>> 24) & 0xFF) / 255)); lastRgb = v; covEdgeRgb = v & 0xFFFFFF; }
           sk.drawRect(CK.XYWHRect(x, H - 1 - y, 1, 1), paint); // flip: high northing at top
           covCells++;
         }
@@ -4678,6 +4682,40 @@ function drawCoverageSk(canvas) {
   // without the per-update mip-regen cost. The surface is cleared to premultiplied
   // TRANSPARENT, so the boundary fades cleanly to transparent (no dark fringe).
   drawImageWorldSk(canvas, cov.skImg, minE, minN, maxE, maxN, CK.FilterMode.Linear, CK.MipmapMode.None);
+}
+// Crisp worked-area edge — the server-fed vector perimeter (only segments that don't adjoin
+// another pass), stroked in the coverage colour over the raster so the soft alpha-AA feather
+// is replaced by a sharp boundary. Bounded by perimeter length, so cost is ~flat regardless
+// of field size. Stroke width ≈ 0.6 m (covers the feather). Polylines are broken at the near
+// plane per vertex (see below). Reloaded fields have no perimeter (graceful fall back to feather).
+function drawCoverageEdgeSk(canvas) {
+  if (EDGE_OFF || !coverageEdges || !coverageEdges.length) return;
+  const p = SKP.covEdge || (SKP.covEdge = (() => {
+    const q = new CK.Paint(); q.setStyle(CK.PaintStyle.Stroke); q.setAntiAlias(true);
+    q.setStrokeCap(CK.StrokeCap.Round); q.setStrokeJoin(CK.StrokeJoin.Round); return q;
+  })());
+  const c = covEdgeRgb;
+  p.setColor(CK.Color((c >> 16) & 0xFF, (c >> 8) & 0xFF, c & 0xFF, 1));
+  p.setStrokeWidth(Math.max(1, 0.6 * pxPerM));
+  // Per-vertex near-plane gate: a vertex at/behind the near plane (homogeneous w ≤ NEAR)
+  // projects through w2s to a huge/flipped coord, so a polyline crossing behind the camera
+  // would shoot a stroke to infinity (seen on zoom/tilt). Break the polyline at those
+  // vertices and draw each in-front run separately — no clipping math, no infinity lines.
+  const NEAR = 0.02;
+  const flush = (cmds) => {
+    if (cmds && cmds.length >= 6) { const path = CK.Path.MakeFromCmds(cmds); if (path) { canvas.drawPath(path, p); path.delete(); } }
+  };
+  for (const pl of coverageEdges) {
+    if (pl.length < 2) continue;
+    let cmds = null;
+    for (let i = 0; i < pl.length; i++) {
+      if (pw(pl[i].e, pl[i].n) < NEAR) { flush(cmds); cmds = null; continue; } // behind near plane → break
+      const xy = w2s(pl[i].e, pl[i].n);
+      if (!cmds) cmds = [CK.MOVE_VERB, xy[0], xy[1]];
+      else cmds.push(CK.LINE_VERB, xy[0], xy[1]);
+    }
+    flush(cmds);
+  }
 }
 // Tool/section footprint — section bars perpendicular to the (dead-reckoned) tool
 // heading, coloured by ColorCode. Same geometry as the 2D toolFootprint().
@@ -4779,6 +4817,7 @@ function renderSkia(canvas, rp) {
   drawSatelliteSk(canvas); // Bing aerial underlay while drawing a boundary on map
   drawImagerySk(canvas); // imagery overlays the ground where present
   drawCoverageSk(canvas);
+  drawCoverageEdgeSk(canvas); // crisp vector perimeter over the raster (server-fed)
   drawGridSk(canvas);
   if (scene) {
     for (let bi = 0; bi < scene.boundaries.length; bi++)

--- a/Shared/AgOpenWeb.RemoteServer/wwwroot/transport.js
+++ b/Shared/AgOpenWeb.RemoteServer/wwwroot/transport.js
@@ -24,7 +24,7 @@ window.RemoteTransport = {
     const url = `${proto}//${location.host}/ws`;
     let ws = null, stopped = false;
 
-    const TYPE = { SCENE: 1, TICK: 2, COVERAGE_INIT: 3, COVERAGE_CELLS: 4, STATUS: 5, CONTROL_STATE: 6, HELLO: 7, CONFIG: 8, PROFILES: 9, WIZARD: 10, NTRIP_PROFILES: 11, FIELD_OPS: 12, AGSHARE: 13, APP_INFO: 14, FIELD_TOOLS: 15, RECORDED_PATH: 16, BOUNDARY: 17, SOUND: 18, PONG: 19 };
+    const TYPE = { SCENE: 1, TICK: 2, COVERAGE_INIT: 3, COVERAGE_CELLS: 4, STATUS: 5, CONTROL_STATE: 6, HELLO: 7, CONFIG: 8, PROFILES: 9, WIZARD: 10, NTRIP_PROFILES: 11, FIELD_OPS: 12, AGSHARE: 13, APP_INFO: 14, FIELD_TOOLS: 15, RECORDED_PATH: 16, BOUNDARY: 17, SOUND: 18, PONG: 19, COVERAGE_EDGE: 20 };
     const td = new TextDecoder();
 
     function decode(buffer) {
@@ -338,6 +338,13 @@ window.RemoteTransport = {
           // One-shot alert: payload is a single SoundEffect id. The host already
           // applied the per-sound config gating; the client just plays it.
           handlers.onSound && handlers.onSound(u8());
+          break;
+        }
+        case TYPE.COVERAGE_EDGE: {
+          // Crisp worked-area edge: a set of perimeter polylines (field-local metres).
+          const pc = i32(); const polylines = new Array(pc);
+          for (let k = 0; k < pc; k++) polylines[k] = pts();
+          handlers.onCoverageEdge && handlers.onCoverageEdge(polylines);
           break;
         }
         case TYPE.PONG: {

--- a/Shared/AgOpenWeb.Services/Coverage/CoverageMapService.cs
+++ b/Shared/AgOpenWeb.Services/Coverage/CoverageMapService.cs
@@ -182,6 +182,29 @@ public class CoverageMapService : ICoverageMapService
         }
     }
 
+    // ---- Vector perimeter (server-fed crisp edge) ----
+    // The swept tool-edge ribbon per mapping run, as distance-gated (left,right) pairs.
+    // GetCoveragePerimeter() walks these and keeps only vertices whose OUTWARD side is
+    // unworked — the true worked-area boundary — which self-prunes as adjacent passes fill
+    // in, so it stays bounded by perimeter length, not worked area. Live-only: a reloaded
+    // field's coverage has no ribbons and falls back to the alpha-AA feather until re-driven.
+    // All of this is mutated/read under _coverageLock.
+    private sealed class EdgeRun { public readonly List<Vec2> Left = new(); public readonly List<Vec2> Right = new(); }
+    private readonly Dictionary<int, EdgeRun> _edgeRunByZone = new();
+    private readonly List<EdgeRun> _edgeRuns = new();
+    private readonly Dictionary<int, (double E, double N)> _edgeGateLast = new();
+    private int _edgePointCount;
+    private const double EDGE_GATE = 2.0;          // metres between committed edge vertex pairs
+    private const int EDGE_MAX_POINTS = 200_000;   // safety cap on total accumulated points
+
+    private void ClearEdges()
+    {
+        _edgeRunByZone.Clear();
+        _edgeRuns.Clear();
+        _edgeGateLast.Clear();
+        _edgePointCount = 0;
+    }
+
     public void StartMapping(int zoneIndex, Vec2 leftEdge, Vec2 rightEdge, CoverageColor? color = null)
     {
         lock (_coverageLock)
@@ -193,6 +216,18 @@ public class CoverageMapService : ICoverageMapService
             _lastEdgesPerSection[zoneIndex] = (
                 (leftEdge.Easting, leftEdge.Northing),
                 (rightEdge.Easting, rightEdge.Northing));
+
+            // Open a fresh edge ribbon for this run, seeded with the first pair.
+            if (_edgePointCount < EDGE_MAX_POINTS)
+            {
+                var run = new EdgeRun();
+                run.Left.Add(leftEdge); run.Right.Add(rightEdge);
+                _edgeRunByZone[zoneIndex] = run;
+                _edgeRuns.Add(run);
+                _edgeGateLast[zoneIndex] =
+                    ((leftEdge.Easting + rightEdge.Easting) * 0.5, (leftEdge.Northing + rightEdge.Northing) * 0.5);
+                _edgePointCount++;
+            }
         }
     }
 
@@ -205,6 +240,9 @@ public class CoverageMapService : ICoverageMapService
 
             _activeSections.Remove(zoneIndex);
             _lastEdgesPerSection.Remove(zoneIndex);
+            // Close the edge ribbon (it stays in _edgeRuns for the perimeter walk).
+            _edgeRunByZone.Remove(zoneIndex);
+            _edgeGateLast.Remove(zoneIndex);
         }
     }
 
@@ -286,6 +324,9 @@ public class CoverageMapService : ICoverageMapService
         // Rasterize the quad to the coverage bitmap for O(1) detection
         RasterizeQuadToBitmap(zoneIndex, leftEdge, rightEdge);
 
+        // Vector perimeter: append this swept edge pair if the tool moved past the gate.
+        AccumulateEdge(zoneIndex, leftEdge, rightEdge);
+
         // Calculate area of the quad (two triangles)
         double area = CalculateQuadArea(
             lastEdges.Left, lastEdges.Right,
@@ -301,6 +342,63 @@ public class CoverageMapService : ICoverageMapService
         _lastEdgesPerSection[zoneIndex] = (
             (leftEdge.Easting, leftEdge.Northing),
             (rightEdge.Easting, rightEdge.Northing));
+    }
+
+    // Append a swept edge pair to the zone's ribbon, distance-gated. Caller holds _coverageLock.
+    private void AccumulateEdge(int zoneIndex, Vec2 leftEdge, Vec2 rightEdge)
+    {
+        if (_edgePointCount >= EDGE_MAX_POINTS) return;
+        if (!_edgeRunByZone.TryGetValue(zoneIndex, out var run)) return;
+        double cx = (leftEdge.Easting + rightEdge.Easting) * 0.5;
+        double cy = (leftEdge.Northing + rightEdge.Northing) * 0.5;
+        if (_edgeGateLast.TryGetValue(zoneIndex, out var last))
+        {
+            double dx = cx - last.E, dy = cy - last.N;
+            if (dx * dx + dy * dy < EDGE_GATE * EDGE_GATE) return;
+        }
+        run.Left.Add(leftEdge); run.Right.Add(rightEdge);
+        _edgeGateLast[zoneIndex] = (cx, cy);
+        _edgePointCount++;
+    }
+
+    /// <summary>
+    /// Worked-area perimeter as polylines for the crisp vector edge. Walks the accumulated
+    /// swept tool-edge ribbons and keeps only vertices whose OUTWARD side is unworked (probed
+    /// against the detection grid), so interior pass-to-pass seams are dropped and only the
+    /// true boundary remains — bounded by perimeter length, not worked area. Live-only (a
+    /// reloaded field has no ribbons). Cheap O(1) probes; safe to call off the control thread.
+    /// </summary>
+    public IReadOnlyList<IReadOnlyList<Vec2>> GetCoveragePerimeter()
+    {
+        var result = new List<IReadOnlyList<Vec2>>();
+        lock (_coverageLock)
+        {
+            foreach (var run in _edgeRuns)
+            {
+                EmitPerimeterSide(run.Left, run.Right, result);
+                EmitPerimeterSide(run.Right, run.Left, result);
+            }
+        }
+        return result;
+    }
+
+    // Emit contiguous runs of `edge` vertices whose outward side (away from `other`) is
+    // unworked — those are on the worked-area boundary. 0.2 m probe ≈ 2 detection cells out.
+    private void EmitPerimeterSide(List<Vec2> edge, List<Vec2> other, List<IReadOnlyList<Vec2>> result)
+    {
+        List<Vec2>? cur = null;
+        int n = Math.Min(edge.Count, other.Count);
+        for (int i = 0; i < n; i++)
+        {
+            double ox = edge[i].Easting - other[i].Easting;
+            double oy = edge[i].Northing - other[i].Northing;
+            double len = Math.Sqrt(ox * ox + oy * oy);
+            bool perim = len > 1e-6 &&
+                !IsPointCovered(edge[i].Easting + ox / len * 0.2, edge[i].Northing + oy / len * 0.2);
+            if (perim) { (cur ??= new List<Vec2>()).Add(edge[i]); }
+            else if (cur != null) { if (cur.Count >= 2) result.Add(cur); cur = null; }
+        }
+        if (cur != null && cur.Count >= 2) result.Add(cur);
     }
 
     /// <summary>
@@ -1004,6 +1102,7 @@ public class CoverageMapService : ICoverageMapService
         // Clear tracking state
         _activeSections.Clear();
         _lastEdgesPerSection.Clear();
+        ClearEdges();
 
         // Reset totals
         _totalWorkedArea = 0;
@@ -1036,6 +1135,8 @@ public class CoverageMapService : ICoverageMapService
         SetFieldBounds(easting - halfSize, easting + halfSize, northing - halfSize, northing + halfSize);
         Console.WriteLine($"[Coverage] Auto-initialized bounds from position ({easting:F1}, {northing:F1}), {halfSize * 2}m x {halfSize * 2}m");
     }
+
+    private bool _inExpansion; // set by CheckAndExpandBounds so SetFieldBounds keeps the edge ribbons
 
     public void SetFieldBounds(double minE, double maxE, double minN, double maxN)
     {
@@ -1075,6 +1176,9 @@ public class CoverageMapService : ICoverageMapService
             Array.Clear(_detectionBits, 0, _detectionBits.Length);
         else
             _detectionBits = new byte[totalBytes];
+        // New field → drop stale ribbons. Expansion keeps them: edges are absolute-coordinate
+        // and CheckAndExpandBounds copies the detection bits across, so the perimeter stays valid.
+        if (!_inExpansion) ClearEdges();
 
         // Compute display resolution + dimensions (pillared on
         // DisplayConfig.DisplayResolutionMultiplier and a 25M-pixel cap)
@@ -1225,8 +1329,10 @@ public class CoverageMapService : ICoverageMapService
         double oldMinE = _fieldMinE;
         double oldMinN = _fieldMinN;
 
-        // Reallocate with new bounds
-        SetFieldBounds(newMinE, newMaxE, newMinN, newMaxN);
+        // Reallocate with new bounds (keep the edge ribbons — detection is copied below)
+        _inExpansion = true;
+        try { SetFieldBounds(newMinE, newMaxE, newMinN, newMaxN); }
+        finally { _inExpansion = false; }
 
         // Copy old detection bits to new array
         if (oldBits != null && _detectionBits != null)
@@ -1315,6 +1421,7 @@ public class CoverageMapService : ICoverageMapService
         // 981-996). Nulling here silently defeats the reuse on every
         // close+reopen and forces a fresh ~73 MB LOH alloc.
         _dirtyValid = false;
+        ClearEdges();
         Console.WriteLine("[Coverage] Field bounds cleared");
     }
 

--- a/Shared/AgOpenWeb.Services/Interfaces/ICoverageMapService.cs
+++ b/Shared/AgOpenWeb.Services/Interfaces/ICoverageMapService.cs
@@ -178,6 +178,14 @@ public interface ICoverageMapService
     int GetDisplayCellAlpha255(int displayX, int displayY);
 
     /// <summary>
+    /// Worked-area perimeter as polylines (field-local metres) for the crisp vector edge:
+    /// the swept tool-edge segments whose outward side is unworked, so interior pass-to-pass
+    /// seams are excluded and the result is bounded by perimeter length, not worked area.
+    /// Live-driven coverage only (a reloaded field has no ribbons).
+    /// </summary>
+    IReadOnlyList<IReadOnlyList<Vec2>> GetCoveragePerimeter();
+
+    /// <summary>
     /// Get patches for a specific zone
     /// </summary>
     /// <param name="zoneIndex">Zone index (0-based)</param>

--- a/sys/version.h
+++ b/sys/version.h
@@ -5,7 +5,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 6
-#define VERSION_PATCH 59
+#define VERSION_PATCH 60
 
-#define VERSION "26.6.59"
+#define VERSION "26.6.60"
 #define VERSION_DATE "2026-06-30"


### PR DESCRIPTION
## What

Adds a **crisp** worked-area boundary on top of the alpha-AA raster — at a cost **bounded by perimeter length, not worked area**. Verified on the physical iPad: flat FPS to **75 acres**, LINK steady ~8 ms.

Builds on the insight that the jagged edge is only ever visible on the **outer perimeter** (interior pass-to-pass seams self-fill to opaque), so we only need to draw the segments that don't adjoin another pass.

## Server (`CoverageMapService`)
- Accumulate the swept tool-edge ribbon per mapping run as distance-gated `(left,right)` pairs (`StartMapping`/`AddCoveragePoint`/`StopMapping`).
- `GetCoveragePerimeter()` walks the ribbons and keeps only vertices whose **outward** side is unworked (`IsPointCovered` probe 0.2 m out) → interior seams dropped, only the true boundary remains. **Self-prunes** as adjacent passes fill in. Cheap O(1) bit probes, off the render thread (host runs ~10–13 % even on a Pi Zero 2W).
- **Bounds expansion preserves the ribbons** (edges are absolute-coordinate and `CheckAndExpandBounds` copies the detection bits across); only a real field change clears them.

## Wire / broadcast
- New `CoverageEdge` message (type 20): perimeter polylines, broadcast ~2 Hz from `MapBroadcaster` (bounded payload).

## Client (`app.js`)
- Stroke the polylines crisp (~0.6 m, AA) in the coverage colour over the raster, replacing the soft feather at the boundary.
- **Per-vertex near-plane gate** breaks polylines crossing behind the camera — no runaway "lines to infinity" on tilt/zoom.
- `?noedge` disables the draw for A/B testing.

## Scope / caveats
- **Live-driven coverage only:** a reloaded field has no ribbons and gracefully falls back to the alpha-AA feather until re-driven.
- Pre-existing, unrelated tilt-FPS issue (the dashed reference line's dash cost to the horizon) was identified during testing and confirmed **independent** of this change (`?noedge` still shows it) — it'll be a separate PR.

## Test
- Desktop build green.
- iPad: crisp edge, flat FPS to 75 acres, steady LINK; interior flecking-free; survives bounds expansion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)