### PR TITLE
Web UI: prevent iOS double-tap page zoom

### DIFF
--- a/Shared/AgOpenWeb.RemoteServer/wwwroot/app.js
+++ b/Shared/AgOpenWeb.RemoteServer/wwwroot/app.js
@@ -503,6 +503,17 @@ for (const t of ['gesturestart', 'gesturechange', 'gestureend'])
 // 2+-finger move is a pinch — swallow it so the page can't zoom/pan. Single-finger
 // touches pass through to the map pan / panel scroll untouched.
 addEventListener('touchmove', e => { if (e.touches.length > 1) e.preventDefault(); }, { passive: false });
+// iOS double-tap-to-zoom is NOT a gesture* event and slips past per-element touch-action when
+// rapid taps land between/across nav buttons → it magnifies the whole page (chrome off-screen)
+// and thrashes layout (render stutter / audio glitch / LINK spike are that main-thread jank).
+// Swallow the 2nd tap's default within 300 ms; the UI runs on pointerdown, so button presses
+// still register.
+let _lastTapEnd = 0;
+addEventListener('touchend', e => {
+  const now = Date.now();
+  if (now - _lastTapEnd <= 300) e.preventDefault();
+  _lastTapEnd = now;
+}, { passive: false });
 
 // Pan + tap. A gesture that moves past TAP_SLOP px pans (and drops to Free mode); one
 // that stays put is a TAP. Overlays (panels/toolbars) stopPropagation their pointerdown,

--- a/Shared/AgOpenWeb.RemoteServer/wwwroot/index.html
+++ b/Shared/AgOpenWeb.RemoteServer/wwwroot/index.html
@@ -67,7 +67,7 @@
       --chip-bg: rgba(224,231,241,0.95);
       --flyout-bg: rgba(245,248,252,0.98);
     }
-    html, body { margin: 0; height: 100%; background: var(--bg-input); overflow: hidden; }
+    html, body { margin: 0; height: 100%; background: var(--bg-input); overflow: hidden; touch-action: manipulation; }
     #ck { position: fixed; inset: 0; display: block; touch-action: none; } /* CanvasKit (Skia) — the only renderer */
     /* Top status bar (Phase 1) — mirrors the native StatusBarPanel: pause + two-line
        left stack (Fix/Age over a rotating Field/Stats/AB line), aggregate Modules


### PR DESCRIPTION
## What

Rapid taps on the nav buttons could trigger iOS Safari's **double-tap-to-zoom**, magnifying the whole page so the status/nav bars fly off-screen — and the resulting layout thrash showed up as an audio glitch + render stutter (and a LINK spike on the diag line, which was just the main thread choking).

iOS ignores the viewport's `user-scalable=no`, and per-element `touch-action` only covers taps landing squarely on a button; rapid taps that land between/across buttons fall through to the page and zoom it.

## Fix
- `html, body { touch-action: manipulation }` — disables double-tap zoom page-wide (the map canvas keeps its own `touch-action: none`).
- A global `touchend` guard swallows the 2nd tap's default within 300 ms. The UI runs on `pointerdown`, so button presses are unaffected.

Pinch-zoom was already handled (`gesture*` preventDefault + 2-finger `touchmove`); this closes the double-tap gap.

## Test
Confirmed on Android + iPad: rapid button mashing no longer zooms the page or glitches; normal taps/pan/scroll unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)