### PR TITLE
Ignore lateral snap / u-turn while a turn is executing (#50)

### DIFF
--- a/Shared/AgOpenWeb.RemoteServer/Contracts.cs
+++ b/Shared/AgOpenWeb.RemoteServer/Contracts.cs
@@ -152,7 +152,12 @@ public record TickDto(
     // pose/tool on THIS timeline, not on frame-receipt time — so WiFi arrival jitter
     // (which warped the receipt-delta and made the heading/map wiggle) only shifts the
     // playback buffer, absorbed by RENDER_DELAY, instead of varying the interp rate.
-    double HostMs);
+    double HostMs,
+    // True while a u-turn arc is executing (mid-turn). The client blocks the on-screen
+    // U-turn/Lateral buttons with a hint during this window — snapping/turning mid-arc is
+    // ignored by the pipeline (would move the displayed track while the tractor stays
+    // committed to the current arc). Mirrors YouTurnState.IsExecuting (issue #50).
+    bool IsYouTurnExecuting);
 
 /// <summary>Top status-bar readouts (Phase 1), sent at a low rate. GPS fix quality
 /// + correction age + sat count; the units preference (so the client formats speed

--- a/Shared/AgOpenWeb.RemoteServer/SceneProjector.cs
+++ b/Shared/AgOpenWeb.RemoteServer/SceneProjector.cs
@@ -308,7 +308,9 @@ public sealed class SceneProjector
             // broadcast-now before the first render-pull (same Stopwatch basis, monotonic).
             v.RenderPoseMs > 0
                 ? v.RenderPoseMs
-                : System.Diagnostics.Stopwatch.GetTimestamp() * 1000.0 / System.Diagnostics.Stopwatch.Frequency);
+                : System.Diagnostics.Stopwatch.GetTimestamp() * 1000.0 / System.Diagnostics.Stopwatch.Frequency,
+            // Mid-turn gate (issue #50): true while the u-turn arc is executing.
+            _state.YouTurn.IsExecuting);
     }
 
     // Top status-bar readouts (Phase 1). All state-projected: fix/age/sats from

--- a/Shared/AgOpenWeb.RemoteServer/WireCodec.cs
+++ b/Shared/AgOpenWeb.RemoteServer/WireCodec.cs
@@ -513,6 +513,7 @@ public static class WireCodec
         w.Write(t.HitchN);           // f64
         w.Write((float)t.VehicleSteerAngle); // front-wheel sprite angle (deg)
         w.Write(t.HostMs);           // f64 — host monotonic build time (client interp timeline)
+        w.Write((byte)(t.IsYouTurnExecuting ? 1 : 0)); // #50 — mid-turn gate for on-screen buttons
         return ms.ToArray();
     }
 

--- a/Shared/AgOpenWeb.RemoteServer/wwwroot/app.js
+++ b/Shared/AgOpenWeb.RemoteServer/wwwroot/app.js
@@ -868,6 +868,10 @@ onScreenBtns.addEventListener('pointerdown', e => {
   const btn = e.target.closest('button[data-cmd]');
   if (!btn) return;
   e.stopPropagation(); // tap the glyph, don't pan the map
+  // #50: mid-turn snaps/u-turns are ignored by the pipeline (they'd shift the
+  // displayed track while the tractor stays committed to the executing arc, then
+  // seek across after). Block them here with a hint instead of silently no-op'ing.
+  if (tick && tick.op && tick.op.executing) { flashHint('Finish the U-turn first'); return; }
   transport.send(btn.dataset.cmd);
 });
 function applyOnScreenButtons() {

--- a/Shared/AgOpenWeb.RemoteServer/wwwroot/transport.js
+++ b/Shared/AgOpenWeb.RemoteServer/wwwroot/transport.js
@@ -106,6 +106,7 @@ window.RemoteTransport = {
           const hitchE = f64(), hitchN = f64();
           const vehicleSteerAngle = f32();
           const hostMs = f64(); // host monotonic build time — the interp timeline
+          op.executing = !!u8(); // #50 — u-turn arc executing (blocks on-screen U-turn/Lateral)
           handlers.onTick && handlers.onTick({
             sceneVersion, pose, fix, sections, crossTrackError, guidanceActive, lineLabel,
             activeTrackName: atn.length ? atn : null, tool, op, roll, tools,

--- a/Shared/AgOpenWeb.Services/Pipeline/GpsPipelineService.cs
+++ b/Shared/AgOpenWeb.Services/Pipeline/GpsPipelineService.cs
@@ -406,7 +406,14 @@ public sealed class GpsPipelineService : IGpsPipelineService
         var intents = _intents.Drain();
         if (intents.ClearYouTurn)
             YouTurnStateMachine.ClearState(_youTurn);
-        if (intents.GuidanceSnap.HasValue)
+        // #50. A snap mid-turn is IGNORED entirely: applying it would shift the
+        // displayed track (HowManyPathsAway) while the tractor is committed to the
+        // executing arc's already-computed target — so it lands on the OLD pass and
+        // then laterally seeks across to the just-snapped one (operator-confirmed as
+        // the confusing behavior). The arc can't be safely re-planned mid-swing, so
+        // we drop the snap outright; the client also hints "finish the turn first".
+        // The armed-but-not-executing case still re-plans cleanly below (#408).
+        if (intents.GuidanceSnap.HasValue && !_youTurn.IsExecuting)
         {
             // Phase D D4. IsHeadingSameWay is the cycle's view of whether the
             // tractor is aligned with the track direction. Snap "left" from
@@ -425,8 +432,7 @@ public sealed class GpsPipelineService : IGpsPipelineService
             // armed arc and lands on the *old* NextTrack (the original
             // exit pass) instead of replanning for the just-snapped pass.
             // Mirrors the direction-override re-arm in YouTurnStateMachine.
-            // Mid-arc snaps are unsafe and stay no-op.
-            if (_youTurn.TurnPath != null && !_youTurn.IsExecuting)
+            if (_youTurn.TurnPath != null)
             {
                 _youTurn.TurnPath = null;
                 _youTurn.NextTrack = null;

--- a/sys/version.h
+++ b/sys/version.h
@@ -5,7 +5,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 6
-#define VERSION_PATCH 62
+#define VERSION_PATCH 63
 
-#define VERSION "26.6.62"
-#define VERSION_DATE "2026-06-30"
+#define VERSION "26.6.63"
+#define VERSION_DATE "2026-07-01"


### PR DESCRIPTION
Closes #50

## Reframe
Investigation showed the on-screen **U-turn / Lateral buttons do trigger** — the literal "don't trigger" isn't reproducible. The reproducible issue (operator-confirmed) is **mid-turn**:

> Near a border, tapping Lateral during/just-before a u-turn moves the track over, but the tractor continues its current u-turn onto the old track, then seeks across to the new one once complete.

Root cause: the snap intent applied `HowManyPathsAway` immediately (shifting the *displayed* track) while the tractor stayed committed to the executing arc's already-computed target. Manual u-turns set `IsExecuting` immediately, so they're always in this state.

## Fix
- **Pipeline** (`GpsPipelineService`): a `GuidanceSnap` intent is now **ignored entirely while a u-turn is executing** — no displayed-track shift, so no mismatch/post-turn seek. The armed-but-not-executing case still re-plans cleanly (#408 preserved).
- **Feedback** (was a silent no-op): `TickDto` gains `IsYouTurnExecuting`; the on-screen U-turn/Lateral buttons now `flashHint("Finish the U-turn first")` and skip the send while a turn executes, instead of appearing to do nothing.

## Testing
- Services (1025) + ViewModels (222) suites pass; Desktop builds clean.
- Manual: near a boundary, engage autosteer on an AB line, start a u-turn, tap Lateral/U-turn mid-arc → button hints and nothing shifts; tap after the turn completes → snaps normally.

## Note (separate, not in this PR)
The on-screen U-turn/Lateral buttons are the only Tier-2 controls that don't dim/gate on `iHoldControl` like the section bar / bottom nav. Not the cause here (reporter holds control), but worth a small follow-up for consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)