### PR TITLE
AB/track creation & guidance-line UX overhaul

### DIFF
--- a/Shared/AgOpenWeb.Models/GeoJson/GeoJsonModels.cs
+++ b/Shared/AgOpenWeb.Models/GeoJson/GeoJsonModels.cs
@@ -89,6 +89,7 @@ public static class FieldPropertyKeys
     public const string Name = "name";
     public const string TrackType = "trackType";
     public const string IsClosed = "isClosed";
+    public const string NoPassOffset = "noPassOffset";
     public const string NudgeDistance = "nudgeDistance";
     public const string IsVisible = "isVisible";
     public const string IsDriveThrough = "isDriveThrough";

--- a/Shared/AgOpenWeb.Models/Track/Track.cs
+++ b/Shared/AgOpenWeb.Models/Track/Track.cs
@@ -91,6 +91,13 @@ public class Track : INotifyPropertyChanged
     public bool IsClosed { get; set; }
 
     /// <summary>
+    /// Drive this track directly (pass 0) instead of free-drive snapping to the nearest
+    /// parallel pass. Set for boundary-follow curves — you drive the boundary itself, not
+    /// offset passes of it. The guidance keeps the reference line, no pass offsetting.
+    /// </summary>
+    public bool NoPassOffset { get; set; }
+
+    /// <summary>
     /// Whether this track is currently active for guidance.
     /// </summary>
     private bool _isActive;

--- a/Shared/AgOpenWeb.RemoteServer/Contracts.cs
+++ b/Shared/AgOpenWeb.RemoteServer/Contracts.cs
@@ -157,7 +157,11 @@ public record TickDto(
     // U-turn/Lateral buttons with a hint during this window — snapping/turning mid-arc is
     // ignored by the pipeline (would move the displayed track while the tractor stays
     // committed to the current arc). Mirrors YouTurnState.IsExecuting (issue #50).
-    bool IsYouTurnExecuting);
+    bool IsYouTurnExecuting,
+    // Current guidance pass offset from the reference (HowManyPathsAway; 0 = on the reference
+    // line). The client draws the purple reference only when this is non-zero (on pass 0 it
+    // would overlap the magenta), and shows a 1-based pass label.
+    int PassNumber);
 
 /// <summary>Top status-bar readouts (Phase 1), sent at a low rate. GPS fix quality
 /// + correction age + sat count; the units preference (so the client formats speed

--- a/Shared/AgOpenWeb.RemoteServer/SceneProjector.cs
+++ b/Shared/AgOpenWeb.RemoteServer/SceneProjector.cs
@@ -310,7 +310,8 @@ public sealed class SceneProjector
                 ? v.RenderPoseMs
                 : System.Diagnostics.Stopwatch.GetTimestamp() * 1000.0 / System.Diagnostics.Stopwatch.Frequency,
             // Mid-turn gate (issue #50): true while the u-turn arc is executing.
-            _state.YouTurn.IsExecuting);
+            _state.YouTurn.IsExecuting,
+            _state.Guidance.HowManyPathsAway); // pass offset (0 = on reference) — #reference/label
     }
 
     // Top status-bar readouts (Phase 1). All state-projected: fix/age/sats from

--- a/Shared/AgOpenWeb.RemoteServer/WireCodec.cs
+++ b/Shared/AgOpenWeb.RemoteServer/WireCodec.cs
@@ -514,6 +514,7 @@ public static class WireCodec
         w.Write((float)t.VehicleSteerAngle); // front-wheel sprite angle (deg)
         w.Write(t.HostMs);           // f64 — host monotonic build time (client interp timeline)
         w.Write((byte)(t.IsYouTurnExecuting ? 1 : 0)); // #50 — mid-turn gate for on-screen buttons
+        w.Write(t.PassNumber);       // i32 — guidance pass offset (0 = on reference)
         return ms.ToArray();
     }
 

--- a/Shared/AgOpenWeb.RemoteServer/wwwroot/app.js
+++ b/Shared/AgOpenWeb.RemoteServer/wwwroot/app.js
@@ -565,7 +565,11 @@ addEventListener('pointerup', e => {
   gestureOnMap = false;
 });
 addEventListener('pointermove', e => {
-  if (mapTap && (abFlow === 'straight' || abFlow === 'curve')) updateAbCursorLabel(e.clientX, e.clientY); // #40 A/B/… on crosshair
+  // #40: the crosshair letter is a MOUSE-hover affordance — only for a real pointer. On
+  // touch/pen there's no hover to ride, and a tap's micro-move would drop the "big A" under
+  // the finger/button and clash with the placed-dot label; touch relies on the dot letters
+  // + the "Tap Point A/B" banner instead.
+  if (mapTap && (abFlow === 'straight' || abFlow === 'curve') && e.pointerType === 'mouse') updateAbCursorLabel(e.clientX, e.clientY);
   if (editDragIdx >= 0 && editSession) {       // drag the grabbed handle
     const w = s2w(e.clientX, e.clientY);
     if (w) editSession.points[editDragIdx] = editSession.kind === 'headland' ? hlSnap(w.e, w.n) : { e: w.e, n: w.n };
@@ -595,11 +599,16 @@ function startMapTap(cfg) {
   document.body.classList.add('maptap'); // crosshair cursor (CSS)
   const h = document.getElementById('maptap-hint');
   h.textContent = cfg.hint || 'Tap the map'; h.classList.add('show');
+  // Touch cancel: only for bare flows (no draw toolbar) — flag placement. The AB/sat/headland
+  // flows show the toolbar whose own Cancel handles them, so don't double it up.
+  const tbUp = document.getElementById('draw-toolbar').classList.contains('show');
+  document.getElementById('maptap-cancel').classList.toggle('show', !tbUp);
 }
 function endMapTap() {
   mapTap = null;
   document.body.classList.remove('maptap');
   document.getElementById('maptap-hint').classList.remove('show');
+  document.getElementById('maptap-cancel').classList.remove('show'); // hide the touch-cancel pill
   if (abLabelEl) abLabelEl.classList.remove('show'); // #40 hide the A/B crosshair letter
   if (abDotLabelsEl) for (const s of abDotLabelsEl.children) s.style.display = 'none'; // + the dot letters
 }
@@ -1005,7 +1014,9 @@ document.getElementById('bn-abmenu').addEventListener('pointerdown', e => { e.st
 let drawMode = null;     // 'straight' | 'curve' (map-tap modes only) — drives the preview
 let drawPts = [];        // [{e,n}] captured so far — preview only (host holds the real list)
 let abFlow = null;       // 'straight' | 'curve' | 'driveAB' | 'recordCurve' | null
-let driveStep = 0;       // Drive-AB: 0 → next press sets A, 1 → next sets B
+let driveStep = 0;       // Drive-AB / record-curve step: 0 → next press sets A/Start, 1 → sets B/End
+let curveMarks = [];     // client-side path dots dropped while driving a record-curve (Set Start→End)
+let _lastCurveMark = null;
 const drawBar = document.getElementById('draw-toolbar');
 const hintEl = document.getElementById('maptap-hint');
 function abHint() {
@@ -1013,7 +1024,7 @@ function abHint() {
     case 'straight': return drawPts.length === 0 ? 'Tap Point A' : 'Tap Point B';
     case 'curve': return `Tap points (${drawPts.length}) — Finish when done`;
     case 'driveAB': return driveStep === 0 ? 'Drive to A, then Set Point' : 'Drive to B, then Set Point';
-    case 'recordCurve': return 'Driving curve — Finish when done';
+    case 'recordCurve': return driveStep === 0 ? 'Drive to A, then Set Point A' : 'Drive the curve to B, then Set Point B';
   }
   return '';
 }
@@ -1044,7 +1055,7 @@ function updateAbCursorLabel(x, y) {
 // frame from drawPts (world→screen); cleared when the draw ends. DOM (CanvasKit has no text).
 function renderAbDotLabels() {
   if (!abDotLabelsEl) return;
-  const n = (drawMode && drawPts.length) ? drawPts.length : 0;
+  const n = drawPts.length || 0; // letters for map-tap AND Drive-AB markers (drawMode may be null)
   while (abDotLabelsEl.children.length < n) abDotLabelsEl.appendChild(document.createElement('span'));
   for (let i = 0; i < abDotLabelsEl.children.length; i++) {
     const span = abDotLabelsEl.children[i];
@@ -1071,16 +1082,43 @@ function startDrawTrack(mode) {           // map-tap straight/curve (ungated —
   startMapTap({ hint: abHint(), onTap: drawTap });
 }
 function startDriveAB() {                  // GPS: set A then B at the vehicle (ungated)
-  abFlow = 'driveAB'; driveStep = 0;
+  abFlow = 'driveAB'; driveStep = 0; drawPts = []; // drawPts holds the dropped A/B markers
   transport.send('track.driveAB');
   showAbBar(true, false, false);
+  document.getElementById('draw-setpoint').textContent = 'Set Point A';
   hintEl.classList.add('show'); setAbHint();
 }
-function startRecordCurve() {              // GPS: record by driving (ungated)
-  abFlow = 'recordCurve';
-  transport.send('track.recordCurve');
-  showAbBar(false, false, true);
+function startRecordCurve() {              // GPS: record by driving — Set Start → Set End (ungated)
+  abFlow = 'recordCurve'; driveStep = 0; curveMarks = []; _lastCurveMark = null;
+  // Recording doesn't begin until "Set Start" (deferred track.recordCurve), so the operator
+  // can position at the curve's start first. The set-point button drives the two-step.
+  showAbBar(true, false, false);
+  document.getElementById('draw-setpoint').textContent = 'Set Point A';
   hintEl.classList.add('show'); setAbHint();
+}
+// "Bnd. Curve" — tap point A then point B on the boundary; the host walks the shorter arc
+// between them and builds a curve following the boundary. Points snap to the nearest boundary
+// vertex for display; the host re-snaps authoritatively.
+function nearestBoundaryPt(e, n) {
+  let best = null, bd = Infinity;
+  const bs = scene && scene.boundaries;
+  if (bs) for (const ring of bs) for (const p of ring) {
+    const dx = p.e - e, dy = p.n - n, d = dx * dx + dy * dy;
+    if (d < bd) { bd = d; best = p; }
+  }
+  return best ? { e: best.e, n: best.n } : { e, n };
+}
+function startBoundaryCurve() {
+  abFlow = 'boundaryCurve'; drawPts = [];
+  showAbBar(false, false, false);          // draw toolbar shows just Cancel
+  startMapTap({ hint: 'Tap point A on the boundary', onTap: boundaryCurveTap });
+}
+function boundaryCurveTap(e, n) {
+  drawPts.push(nearestBoundaryPt(e, n));   // snap A/B to the nearest boundary vertex (dot shown)
+  if (drawPts.length < 2) { hintEl.textContent = 'Tap point B on the boundary'; return; }
+  const a = drawPts[0], b = drawPts[1];
+  transport.send('track.boundaryCurveSeg|' + a.e.toFixed(3) + ',' + a.n.toFixed(3) + ',' + b.e.toFixed(3) + ',' + b.n.toFixed(3));
+  endAbFlow();
 }
 function drawTap(e, n) {                    // map-tap point captured (straight/curve)
   drawPts.push({ e, n });
@@ -1089,11 +1127,35 @@ function drawTap(e, n) {                    // map-tap point captured (straight/
   if (abFlow === 'straight' && drawPts.length >= 2) { endAbFlow(); return; }
   setAbHint();
 }
-function abSetPoint() {                     // Drive-AB "Set Point" press
-  if (abFlow !== 'driveAB') return;
-  transport.send('track.setABGps');        // SetABPoint uses live GPS in DriveAB mode
-  if (driveStep === 0) { driveStep = 1; setAbHint(); }
-  else endAbFlow();                        // B set → host created the line
+function abSetPoint() {                     // Set-point button — drives Drive-AB and record-curve
+  const btn = document.getElementById('draw-setpoint');
+  if (abFlow === 'driveAB') {
+    if (driveStep > 1) return;             // guard a double-B while B lingers
+    transport.send('track.setABGps');      // SetABPoint uses live GPS in DriveAB mode
+    // Drop an A/B marker at the vehicle so the operator sees where each point landed.
+    if (tick && tick.pose) drawPts.push({ e: tick.pose.e, n: tick.pose.n });
+    if (driveStep === 0) { driveStep = 1; btn.textContent = 'Set Point B'; setAbHint(); }
+    else {                                  // B set → host created the line; show B a beat, then clear
+      driveStep = 2;
+      setTimeout(() => { if (abFlow === 'driveAB') endAbFlow(); }, 700);
+    }
+  } else if (abFlow === 'recordCurve') {
+    if (driveStep > 1) return;              // guard a double-B while B lingers
+    if (driveStep === 0) {                  // Set Point A → drop the A endpoint + begin recording
+      transport.send('track.recordCurve');
+      driveStep = 1; btn.textContent = 'Set Point B';
+      if (tick && tick.pose) {
+        drawPts.push({ e: tick.pose.e, n: tick.pose.n });   // labeled "A" endpoint dot (orange)
+        _lastCurveMark = { e: tick.pose.e, n: tick.pose.n }; // seed green-dot spacing; no dot at A itself
+      }
+      setAbHint();
+    } else {                                // Set Point B → drop the B endpoint + finish
+      driveStep = 2;
+      if (tick && tick.pose) drawPts.push({ e: tick.pose.e, n: tick.pose.n }); // labeled "B" endpoint dot (blue)
+      transport.send('track.finishCurve');  // host builds the curve from its recorded points
+      setTimeout(() => { if (abFlow === 'recordCurve') endAbFlow(); }, 700);   // show B a beat, then clear
+    }
+  }
 }
 function abUndo() {
   if (abFlow !== 'curve' || !drawPts.length) return;
@@ -1114,9 +1176,30 @@ function abCancel() {
 }
 function endAbFlow() {
   abFlow = null; drawMode = null; drawPts = []; driveStep = 0;
+  curveMarks = []; _lastCurveMark = null; // clear record-curve path dots
   drawBar.classList.remove('show');
   endMapTap();
   hintEl.classList.remove('show');
+}
+// Drop a path dot every ~1.5 m while recording a drive-curve (between Set Point A and B), so
+// the operator sees the shape being captured. Visual only — the host records the real curve.
+function sampleCurveMark() {
+  if (abFlow !== 'recordCurve' || driveStep !== 1 || !tick || !tick.pose) return;
+  const p = tick.pose;
+  if (_lastCurveMark && Math.hypot(p.e - _lastCurveMark.e, p.n - _lastCurveMark.n) < 1.5) return;
+  _lastCurveMark = { e: p.e, n: p.n };
+  curveMarks.push(_lastCurveMark);
+}
+function drawCurveMarksSk(canvas) {
+  if (!curveMarks.length) return;
+  const rad = Math.max(3, 0.4 * pxPerM);
+  SKP.flagFill.setColor(ckColor('#39FF6A')); // recording green
+  for (const p of curveMarks) {
+    if (pw(p.e, p.n) < 1.0) continue; // behind the near plane
+    const xy = w2s(p.e, p.n);
+    canvas.drawCircle(xy[0], xy[1], rad, SKP.flagFill);
+    canvas.drawCircle(xy[0], xy[1], rad, SKP.flagOutline);
+  }
 }
 // ---- boundary draw-on-map (Phase MT) — native BoundaryMapDialog equivalent ----
 // Shows a Bing aerial underlay (satEnabled) and captures the boundary polygon by tapping
@@ -1264,31 +1347,35 @@ document.getElementById('draw-setpoint').addEventListener('pointerdown', e => { 
 document.getElementById('draw-undo').addEventListener('pointerdown', e => { e.preventDefault(); e.stopPropagation(); hlFlow ? hlUndo() : satBnd ? satUndo() : abUndo(); });
 document.getElementById('draw-finish').addEventListener('pointerdown', e => { e.preventDefault(); e.stopPropagation(); editSession ? saveEdit() : hlFlow ? endHeadlandDraw() : satBnd ? satFinish() : abFinish(); });
 document.getElementById('draw-cancel').addEventListener('pointerdown', e => { e.preventDefault(); e.stopPropagation(); editSession ? endEdit() : hlFlow ? endHeadlandDraw() : satBnd ? satCancel() : abCancel(); });
+// Touch cancel for bare map-tap flows (flag). stopPropagation so the pill isn't taken as a map tap.
+document.getElementById('maptap-cancel').addEventListener('pointerdown', e => { e.preventDefault(); e.stopPropagation(); if (mapTap && mapTap.onCancel) mapTap.onCancel(); else endMapTap(); });
 
 // ---- AB flyout launchers → the three creation/management dialogs ----
 function abFlyoutClose() { bnAb.classList.remove('open'); document.getElementById('bn-abmenu').classList.remove('menuopen'); }
 document.getElementById('bn-tracks').addEventListener('pointerdown', e => { e.stopPropagation(); abFlyoutClose(); openTracksManager(); });
 document.getElementById('bn-quickab').addEventListener('pointerdown', e => { e.stopPropagation(); abFlyoutClose(); openDialog('dlg-quickab'); });
-document.getElementById('bn-drawab').addEventListener('pointerdown', e => { e.stopPropagation(); abFlyoutClose(); openDialog('dlg-drawab'); });
 // Quick-AB selector buttons.
+// Quick AB — the single creation hub: GPS-driven, from-boundary, and draw-on-map modes.
 document.getElementById('dlg-quickab').querySelectorAll('[data-qab]').forEach(b => b.addEventListener('pointerdown', e => {
   e.preventDefault(); e.stopPropagation(); closeDialog();
   const m = b.dataset.qab;
-  if (m === 'aPlus') transport.send('track.aPlus');
+  if (m === 'aPlus') {
+    // A+ builds an AB line from the vehicle's current position + heading. It needs a GPS
+    // fix; the host bails silently without one, so give feedback here (StatusMessage isn't
+    // on the wire). flashHint after a tick so it isn't cleared by the dialog close.
+    const p = tick && tick.pose;
+    if (!p || (!p.e && !p.n)) setTimeout(() => flashHint('A+ needs a GPS position — start the simulator or GPS'), 0);
+    else transport.send('track.aPlus');
+  }
   else if (m === 'driveAB') startDriveAB();
   else if (m === 'recordCurve') startRecordCurve();
+  else if (m === 'boundaryEdge') transport.send('track.createFromBoundary');
+  else if (m === 'boundaryCurve') startBoundaryCurve();
+  else if (m === 'allEdges') transport.send('track.allEdges');
+  else if (m === 'drawStraight') startDrawTrack('straight');
+  else if (m === 'drawCurve') startDrawTrack('curve');
 }));
 document.getElementById('dlg-qab-cancel').addEventListener('pointerdown', e => { e.preventDefault(); e.stopPropagation(); closeDialog(); });
-// Draw-AB selector buttons.
-document.getElementById('dlg-drawab').querySelectorAll('[data-draw]').forEach(b => b.addEventListener('pointerdown', e => {
-  e.preventDefault(); e.stopPropagation(); closeDialog();
-  const m = b.dataset.draw;
-  if (m === 'straight' || m === 'curve') startDrawTrack(m);
-  else if (m === 'boundaryEdge') transport.send('track.createFromBoundary');
-  else if (m === 'boundaryCurve') transport.send('track.boundaryCurve');
-  else if (m === 'allEdges') transport.send('track.allEdges');
-}));
-document.getElementById('dlg-drawab-cancel').addEventListener('pointerdown', e => { e.preventDefault(); e.stopPropagation(); closeDialog(); });
 
 // ---- Tracks manager (mirrors native TracksDialogPanel) ----
 // View-only without control (just reads scene.trackList); the actions are Tier-2.
@@ -3381,7 +3468,10 @@ function updateLightbarText() {
     const xte = tick.crossTrackError || 0;
     const onLine = Math.abs(xte) < 0.05;
     const arrow = onLine ? '●' : xte > 0 ? '◀' : '▶'; // arrow = steer direction
-    lbEl.textContent = `${arrow} ${(Math.abs(xte) * 100).toFixed(0)} cm   ${tick.lineLabel || ''}`;
+    // 1-based pass label (human counting): the reference AB line is "Pass 1", one over is
+    // "Pass 2", etc. — magnitude only (the arrow already shows which way to steer).
+    const pass = (tick.op ? tick.op.passNumber : 0) | 0;
+    lbEl.textContent = `${arrow} ${(Math.abs(xte) * 100).toFixed(0)} cm   Pass ${Math.abs(pass) + 1}`;
   }
   lbEl.style.display = 'block';
 }
@@ -4363,7 +4453,7 @@ function drawSatBoundarySk(canvas) {
 // blue B (last), white interior — so the placed A point is visible before B is set. The
 // host holds the real point list; drawPts is the client's tap echo (preview only).
 function drawAbDrawPreviewSk(canvas) {
-  if (!drawMode || !drawPts.length) return;
+  if (!drawPts.length) return; // renders for map-tap AND Drive-AB markers (drawMode may be null)
   const rad = Math.max(5, 0.6 * pxPerM);
   for (let i = 0; i < drawPts.length; i++) {
     const p = drawPts[i];
@@ -4981,19 +5071,23 @@ function renderSkia(canvas, rp) {
     drawExtraGuidelinesSk(canvas); // faint adjacent passes (under the bold lines)
     if (scene.nextTrack) strokePtsSk(canvas, scene.nextTrack, false, SKP.next);
     if (scene.uTurnPath) strokePtsSk(canvas, scene.uTurnPath, false, SKP.uturn);
-    if (scene.guidanceLine) strokePtsSk(canvas, scene.guidanceLine, false, SKP.guidance);
-    // Reference AB (the selected track, fixed at where it was drawn) — purple dashed,
-    // drawn AFTER the magenta DisplayLine so the dashes show on top. scene.tracks is
-    // active-only, so this is just the active reference; the offset magenta sits a pass
-    // away from it once the tractor moves over.
-    for (const tr of scene.tracks)
+    // Purple reference (extended across the field) — drawn ONLY when the tractor is offset from
+    // it (pass ≠ 0). On the reference pass it coincides with the magenta guidance, so we show
+    // just the one line. Matches the host's baseTrack = nearestPass!=0?track:null intent.
+    const _onRef = !tick || !tick.op || (tick.op.passNumber | 0) === 0;
+    if (!_onRef) for (const tr of scene.tracks)
       strokePtsSk(canvas, extendAbLine(tr.points), false, SKP.reference);
+    // Magenta current pass, extended across the field. The host's DisplayLine is only ~track
+    // length (a 2-point offset AB); extendAbLine spans it full-field, so an offset pass isn't a
+    // short stub. Curves are >2 points and already host-extended, so they pass through unchanged.
+    if (scene.guidanceLine) strokePtsSk(canvas, extendAbLine(scene.guidanceLine), false, SKP.guidance);
     drawFlagsSk(canvas, scene.flags);
   }
   drawRecordingMarkersSk(canvas); // live recorded-path dots (independent of the Scene)
   drawBoundaryRecordingSk(canvas); // live drive-around boundary line + dots
   drawSatBoundarySk(canvas); // live boundary-on-satellite polygon being drawn
   drawAbDrawPreviewSk(canvas); // #40 — A/B (orange/blue) dots for the AB/curve being drawn
+  drawCurveMarksSk(canvas); // record-curve path dots (Set Point A → B)
   drawDrawingSk(canvas); // live draw-on-map AB/curve preview (Phase MT)
   drawHeadlandDrawSk(canvas); // live headland draw preview (Field Builder stage 2)
   drawHeadlandSegEditLinesSk(canvas); // headland-editor offset lines (yellow/red) while editing
@@ -5015,6 +5109,7 @@ function skFrame() {
   else { _fpsFrames++; const dt = _now - _fpsT0; if (dt >= 500) { fps = _fpsFrames * 1000 / dt; _fpsFrames = 0; _fpsT0 = _now; } }
   const rp = updateCamera(); // follow mode + rotation + perspM, once per frame
   maybeSaveView();           // persist tilt/zoom changes (debounced) — issue #35
+  sampleCurveMark();         // drop record-curve path dots as the vehicle drives
   if (skSurface) {
     try { renderSkia(skSurface.getCanvas(), rp); skSurface.flush(); }
     catch (e) { ckStatus = 'render err: ' + (e && e.message || e); }

--- a/Shared/AgOpenWeb.RemoteServer/wwwroot/index.html
+++ b/Shared/AgOpenWeb.RemoteServer/wwwroot/index.html
@@ -160,7 +160,16 @@
       pointer-events: none; z-index: 40; box-shadow: 0 2px 10px rgba(0,0,0,0.4);
     }
     #maptap-hint.show { display: block; }
-    #maptap-hint::after { content: '  ·  Esc to cancel'; opacity: 0.6; font-weight: 400; }
+    /* "Esc to cancel" only on pointer devices with a keyboard; touch cancels via the red
+       Cancel button in the draw toolbar (no Esc key on a tablet). */
+    @media (pointer: fine) { #maptap-hint::after { content: '  ·  Esc to cancel'; opacity: 0.6; font-weight: 400; } }
+    /* Touch cancel for bare map-tap flows (flag placement) that have no draw toolbar. Shown
+       by startMapTap only when the toolbar isn't up, so it never doubles the toolbar Cancel. */
+    #maptap-cancel { position: fixed; top: calc(102px + var(--sat)); left: 50%; transform: translateX(-50%);
+      display: none; z-index: 41; padding: 8px 22px; border-radius: 999px; cursor: pointer;
+      border: 1px solid rgba(230,120,110,0.7); background: rgba(52,22,20,0.94); color: #f3c4bd;
+      font: 700 14px system-ui, sans-serif; box-shadow: 0 2px 10px rgba(0,0,0,0.4); }
+    #maptap-cancel.show { display: block; }
     body.maptap #ck { cursor: crosshair; }
     /* A/B letter that rides the crosshair while drawing a straight AB line (#40): shows
        which point the next tap places. Colour matches the placed dots (A orange, B blue). */
@@ -168,6 +177,9 @@
       font: 900 24px system-ui, sans-serif; transform: translate(15px, -30px);
       text-shadow: 0 0 3px #000, 0 1px 5px rgba(0,0,0,0.95); }
     #maptap-ab.show { display: block; }
+    /* The crosshair letter is mouse-only (no hover to ride on touch); the dot letters +
+       banner cover touch. Belt-and-suspenders with the pointerType gate in JS. */
+    @media (pointer: coarse) { #maptap-ab { display: none !important; } }
     /* Persistent letter next to each dropped AB/curve point (#40). Positioned per-frame. */
     #ab-dot-labels span { position: fixed; z-index: 41; display: none; pointer-events: none;
       font: 900 20px system-ui, sans-serif; transform: translate(11px, -26px);
@@ -1100,6 +1112,7 @@
   <div id="lb"></div>
   <div id="headland-hud"></div>
   <div id="maptap-hint"></div>
+  <button id="maptap-cancel">✕ Cancel</button>
   <div id="maptap-ab">A</div>
   <div id="ab-dot-labels"></div>
   <!-- Phase MT — draw-track toolbar. Shown while drawing an AB/curve on the map.
@@ -2458,17 +2471,13 @@
       </div>
       <div id="bn-flyout-ab" class="bn-flyout">
         <!-- Mirrors native BottomNavigationPanel AB flyout. Row 1: Tracks manager /
-             Auto-track / Quick-AB selector. Row 2: boundary-edge AB / Draw-on-map
-             selector. Then the active-track ops (cycle/smooth/delete + nudges), shown
-             only with an active track (.bn-abdep). Tracks/QuickAB/DrawAB open dialogs. -->
+             Auto-track / Quick-AB (the single creation hub — GPS-driven, from-boundary,
+             and draw-on-map all live in its dialog). Then the active-track ops
+             (cycle/smooth/delete + nudges), shown only with an active track (.bn-abdep). -->
         <div class="bn-flyrow">
           <button class="bn-btn" id="bn-tracks" title="Tracks — manage AB lines"><img class="bn-ic" src="/icons/ABTracks.png" alt="Tracks"></button>
           <button class="bn-btn" id="bn-autotrack" data-cmd="track.autoTrack" data-t2 title="Auto track select (closest track)">AT</button>
           <button class="bn-btn" id="bn-quickab" title="Quick AB line creator"><img class="bn-ic" src="/icons/ABTrackAPlus.png" alt="Quick AB"></button>
-        </div>
-        <div class="bn-flyrow">
-          <button class="bn-btn" data-cmd="track.createFromBoundary" title="Create AB line from boundary edge">BE</button>
-          <button class="bn-btn" id="bn-drawab" title="Draw AB line on map"><img class="bn-ic" src="/icons/ABDraw.png" alt="Draw AB"></button>
         </div>
         <div class="bn-flysep bn-abdep"></div>
         <div class="bn-flyrow bn-abdep">
@@ -2544,32 +2553,28 @@
         <button id="ucov-save" class="dlg-btn dlg-ok">Save to Job</button>
       </div>
     </div>
-    <!-- Quick AB Line creator (mirrors native QuickABSelectorPanel) — GPS-driven modes. -->
+    <!-- Quick AB Line — the single AB/track creation hub. Three sections: GPS-driven,
+         from-boundary, and draw-on-map (all methods live here; no separate Draw dialog). -->
     <div id="dlg-quickab" class="dlg-card">
       <div class="dlg-title">Quick AB Line</div>
-      <div class="dlg-msg">Select a creation mode</div>
+      <div class="dlg-sub">By Driving</div>
       <div class="dlg-modes">
         <button class="dlg-mode" data-qab="aPlus" title="AB line from current position &amp; heading"><img src="/icons/ABTrackAPlus.png" alt=""><span>A+</span></button>
         <button class="dlg-mode" data-qab="driveAB" title="Drive from A to B"><img src="/icons/ABTrackAB.png" alt=""><span>Drive AB</span></button>
         <button class="dlg-mode" data-qab="recordCurve" title="Drive to record a curve"><img src="/icons/ABTrackCurve.png" alt=""><span>Curve</span></button>
       </div>
-      <div class="dlg-buttons"><button id="dlg-qab-cancel" class="dlg-btn dlg-cancel">Cancel</button></div>
-    </div>
-    <!-- Draw AB on map (mirrors native DrawABDialogPanel) — map-tap + boundary creation. -->
-    <div id="dlg-drawab" class="dlg-card">
-      <div class="dlg-title">Draw Track on Map</div>
-      <div class="dlg-msg">Tap on the map to place points</div>
-      <div class="dlg-modes">
-        <button class="dlg-mode" data-draw="straight" title="Tap 2 points for a straight AB line"><img src="/icons/ABTrackAB.png" alt=""><span>Straight</span></button>
-        <button class="dlg-mode" data-draw="curve" title="Tap points for a curve, then Finish"><img src="/icons/ABTrackCurve.png" alt=""><span>Curve</span></button>
-      </div>
       <div class="dlg-sub">From Field Boundary</div>
       <div class="dlg-modes">
-        <button class="dlg-mode" data-draw="boundaryEdge" title="AB line along the longest boundary edge"><span class="dlg-bigtxt">AB</span><span>Longest Edge</span></button>
-        <button class="dlg-mode" data-draw="boundaryCurve" title="Curve following the whole boundary"><img src="/icons/ABTrackCurve.png" alt=""><span>Bnd. Curve</span></button>
-        <button class="dlg-mode" data-draw="allEdges" title="AB line for every boundary edge"><span class="dlg-bigtxt">All</span><span>All Edges</span></button>
+        <button class="dlg-mode" data-qab="boundaryEdge" title="AB line along the longest boundary edge"><span class="dlg-bigtxt">AB</span><span>Longest Edge</span></button>
+        <button class="dlg-mode" data-qab="boundaryCurve" title="Curve following the whole boundary"><img src="/icons/ABTrackCurve.png" alt=""><span>Bnd. Curve</span></button>
+        <button class="dlg-mode" data-qab="allEdges" title="AB line for every boundary edge"><span class="dlg-bigtxt">All</span><span>All Edges</span></button>
       </div>
-      <div class="dlg-buttons"><button id="dlg-drawab-cancel" class="dlg-btn dlg-cancel">Cancel</button></div>
+      <div class="dlg-sub">Draw on Map</div>
+      <div class="dlg-modes">
+        <button class="dlg-mode" data-qab="drawStraight" title="Tap 2 points on the map for a straight AB line"><img src="/icons/ABTrackAB.png" alt=""><span>Straight</span></button>
+        <button class="dlg-mode" data-qab="drawCurve" title="Tap points on the map for a curve, then Finish"><img src="/icons/ABTrackCurve.png" alt=""><span>Curve</span></button>
+      </div>
+      <div class="dlg-buttons"><button id="dlg-qab-cancel" class="dlg-btn dlg-cancel">Cancel</button></div>
     </div>
     <!-- Tracks manager (mirrors native TracksDialogPanel) — list + toolbar. -->
     <div id="dlg-tracks" class="dlg-card dlg-wide">

--- a/Shared/AgOpenWeb.RemoteServer/wwwroot/transport.js
+++ b/Shared/AgOpenWeb.RemoteServer/wwwroot/transport.js
@@ -107,6 +107,7 @@ window.RemoteTransport = {
           const vehicleSteerAngle = f32();
           const hostMs = f64(); // host monotonic build time — the interp timeline
           op.executing = !!u8(); // #50 — u-turn arc executing (blocks on-screen U-turn/Lateral)
+          op.passNumber = i32(); // guidance pass offset (0 = on reference) — reference gate + label
           handlers.onTick && handlers.onTick({
             sceneVersion, pose, fix, sections, crossTrackError, guidanceActive, lineLabel,
             activeTrackName: atn.length ? atn : null, tool, op, roll, tools,

--- a/Shared/AgOpenWeb.RemoteWiring/RemoteServerWiring.Helpers.cs
+++ b/Shared/AgOpenWeb.RemoteWiring/RemoteServerWiring.Helpers.cs
@@ -15,7 +15,7 @@ public static partial class RemoteServerWiring
         "track.drawStraight", "track.drawCurve", "track.drawPoint", "track.drawFinish",
         "track.drawUndo", "track.drawCancel", "track.aPlus", "track.driveAB",
         "track.recordCurve", "track.finishCurve", "track.setABGps",
-        "track.createFromBoundary", "track.boundaryCurve", "track.allEdges",
+        "track.createFromBoundary", "track.boundaryCurve", "track.boundaryCurveSeg", "track.allEdges",
         "track.setVisible", "track.toggleRecPaths", "track.editSave",
     };
 

--- a/Shared/AgOpenWeb.RemoteWiring/RemoteServerWiring.cs
+++ b/Shared/AgOpenWeb.RemoteWiring/RemoteServerWiring.cs
@@ -309,6 +309,17 @@ public static partial class RemoteServerWiring
                                     }
                                     return;
                                 }
+                                case "track.boundaryCurveSeg": // "Bnd. Curve": tap A + B on the boundary.
+                                {                              // arg = "aE,aN,bE,bN" (m, from s2w). Tier-1.
+                                    var bc = arg.Split(',');
+                                    if (bc.Length >= 4
+                                        && double.TryParse(bc[0], num, inv, out var caE)
+                                        && double.TryParse(bc[1], num, inv, out var caN)
+                                        && double.TryParse(bc[2], num, inv, out var cbE)
+                                        && double.TryParse(bc[3], num, inv, out var cbN))
+                                        vm.RemoteCreateBoundaryCurveSegment(caE, caN, cbE, cbN);
+                                    return;
+                                }
                                 case "flag.placeAt": // Phase MT map-tap. arg = "easting,northing"
                                 {                     // (m, field-local, from s2w). Tier-1 marker.
                                     var fp = arg.Split(',');

--- a/Shared/AgOpenWeb.Services/GeoJson/GeoJsonFieldService.cs
+++ b/Shared/AgOpenWeb.Services/GeoJson/GeoJsonFieldService.cs
@@ -254,6 +254,7 @@ public class GeoJsonFieldService
                 [FieldPropertyKeys.Name] = track.Name,
                 [FieldPropertyKeys.TrackType] = (int)track.Type,
                 [FieldPropertyKeys.IsClosed] = track.IsClosed,
+                [FieldPropertyKeys.NoPassOffset] = track.NoPassOffset,
                 [FieldPropertyKeys.NudgeDistance] = track.NudgeDistance,
                 [FieldPropertyKeys.IsVisible] = track.IsVisible,
             }
@@ -362,6 +363,7 @@ public class GeoJsonFieldService
             Points = points,
             Type = trackType,
             IsClosed = GetBoolProp(feature, FieldPropertyKeys.IsClosed),
+            NoPassOffset = GetBoolProp(feature, FieldPropertyKeys.NoPassOffset),
             NudgeDistance = GetDoubleProp(feature, FieldPropertyKeys.NudgeDistance),
             IsVisible = GetBoolPropDefault(feature, FieldPropertyKeys.IsVisible, true),
         };

--- a/Shared/AgOpenWeb.Services/Pipeline/GpsPipelineService.cs
+++ b/Shared/AgOpenWeb.Services/Pipeline/GpsPipelineService.cs
@@ -519,6 +519,12 @@ public sealed class GpsPipelineService : IGpsPipelineService
             _nextUTurnDirectionLeftOverride = null;
         }
 
+        // Boundary-follow curve (NoPassOffset): only SUPPRESS the free-drive nearest-pass snap
+        // (below) so it stays where you put it — it starts on the boundary (pass 0, seeded from
+        // NudgeDistance) instead of jumping to the pass nearest a parked tractor. Laterals,
+        // nudges and U-turns still change the pass normally; we don't pin it here.
+        bool noPassOffset = track != null && track.NoPassOffset;
+
         // No-headland workflow: substitute a synthetic headland line that
         // sits one (turn radius + UTurnDistanceFromBoundary) inset from the
         // outer boundary, so the auto-uturn arc's apex lands inside the
@@ -922,7 +928,7 @@ public sealed class GpsPipelineService : IGpsPipelineService
                 _autoSteerService.UpdateGuidanceResults(steerAngle, crossTrackError);
             }
         }
-        if (!autoSteerEngaged && hasTrack)
+        if (!autoSteerEngaged && hasTrack && !noPassOffset)
         {
             // Display-only: auto-detect nearest pass and update visualization.
             // Phase D D3: write the detected pass directly into the cycle's

--- a/Shared/AgOpenWeb.ViewModels/MainViewModel.Commands.Track.cs
+++ b/Shared/AgOpenWeb.ViewModels/MainViewModel.Commands.Track.cs
@@ -68,6 +68,78 @@ public partial class MainViewModel
         StatusMessage = "Applied area deleted";
     }
 
+    /// <summary>
+    /// Boundary curve from two tapped points (remote/web "Bnd. Curve"): snap A and B to the
+    /// nearest outer-boundary vertices, walk the shorter arc between them, and create an OPEN
+    /// curve following the boundary. Mirrors native FormABDraw's BtnMakeCurve segment logic.
+    /// </summary>
+    public void RemoteCreateBoundaryCurveSegment(double aE, double aN, double bE, double bN)
+    {
+        var boundary = State.Field.CurrentBoundary?.OuterBoundary;
+        if (boundary?.Points == null || boundary.Points.Count < 3)
+        {
+            StatusMessage = "Load a field with a boundary first";
+            return;
+        }
+        // Offset the boundary inward by half the tool width so the curve sits half-an-implement
+        // inside the fence (following it keeps the whole implement in the field — #422, same as
+        // the whole-boundary curve). Fall back to the raw boundary if the offset fails.
+        double halfTool = ConfigStore.ActualToolWidth / 2.0;
+        var rawVec2 = new System.Collections.Generic.List<Models.Base.Vec2>(boundary.Points.Count);
+        foreach (var p in boundary.Points) rawVec2.Add(new Models.Base.Vec2(p.Easting, p.Northing));
+        var offset = halfTool > 0.05 ? _polygonOffsetService.CreateInwardOffset(rawVec2, halfTool) : null;
+        var ring = (offset != null && offset.Count >= 3) ? offset : rawVec2;
+        int n = ring.Count;
+
+        int NearestIndex(double e, double north)
+        {
+            int best = 0; double bd = double.MaxValue;
+            for (int i = 0; i < n; i++)
+            {
+                double dx = ring[i].Easting - e, dy = ring[i].Northing - north;
+                double d = dx * dx + dy * dy;
+                if (d < bd) { bd = d; best = i; }
+            }
+            return best;
+        }
+
+        int ai = NearestIndex(aE, aN);
+        int bi = NearestIndex(bE, bN);
+        if (ai == bi) { StatusMessage = "Pick two different points on the boundary"; return; }
+
+        // Walk the SHORTER arc A→B around the closed ring (mirrors FormABDraw's wrap check).
+        int forward = (bi - ai + n) % n;
+        int step = forward <= n - forward ? 1 : -1;
+        var seg = new System.Collections.Generic.List<Models.Base.Vec3>();
+        for (int i = ai; ; i = (i + step + n) % n)
+        {
+            seg.Add(new Models.Base.Vec3(ring[i].Easting, ring[i].Northing, 0));
+            if (i == bi) break;
+        }
+
+        if (seg.Count < 3) { StatusMessage = "Segment too short for a curve"; return; }
+
+        // Round the boundary's sharp corners so the tractor can actually drive it (Chaikin
+        // corner-cutting), then heading per point (guidance's forward test keys off it).
+        var smoothed = Models.Guidance.CurveProcessing.ChaikinsSmooth(seg, 3);
+        var curvePoints = Models.Guidance.CurveProcessing.CalculateHeadings(smoothed);
+        var track = new Models.Track.Track
+        {
+            Name = "Boundary Curve",
+            Points = curvePoints,
+            Type = Models.Track.TrackType.Curve,
+            IsVisible = true,
+            IsClosed = false,
+            // Drive the boundary itself: this curve isn't worked in parallel passes, so the
+            // guidance follows it directly (pass 0) instead of free-drive snapping to an inner pass.
+            NoPassOffset = true
+        };
+        SavedTracks.Add(track);
+        SelectedTrack = track;
+        SaveTracksToFile();
+        StatusMessage = $"Created boundary curve ({curvePoints.Count} points, {halfTool:F1} m inside fence)";
+    }
+
     private void InitializeTrackCommands()
     {
         // AB Line Guidance Commands - Bottom Bar

--- a/Shared/AgOpenWeb.ViewModels/MainViewModel.GpsHandling.cs
+++ b/Shared/AgOpenWeb.ViewModels/MainViewModel.GpsHandling.cs
@@ -417,7 +417,12 @@ public partial class MainViewModel
         _gpsPipelineService.SetHeadlandLine(State.Field.HeadlandLine);
         _gpsPipelineService.SetDriftCompensation(State.Field.DriftEasting, State.Field.DriftNorthing);
         // Never arm U-turns on a closed/polygon track, regardless of the toggle (#421).
-        _gpsPipelineService.SetYouTurnEnabled(IsYouTurnEnabled && !IsActiveTrackClosed);
+        // Stopgap: also skip auto-U-turns on a boundary-follow (NoPassOffset) curve — auto
+        // arming is headland-proximity based and mis-fires on a line that hugs the boundary
+        // (fires at the first corner, return path outside the fence). Manual U-turns still work.
+        // Proper end-of-pass auto-U-turns for boundary curves are a separate follow-up.
+        _gpsPipelineService.SetYouTurnEnabled(
+            IsYouTurnEnabled && !IsActiveTrackClosed && !(SelectedTrack?.NoPassOffset == true));
         _gpsPipelineService.SetYouTurnConfig(
             UTurnSkipRows, IsSkipWorkedMode, HeadlandCalculatedWidth, HeadlandDistance);
     }

--- a/sys/version.h
+++ b/sys/version.h
@@ -5,7 +5,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 6
-#define VERSION_PATCH 65
+#define VERSION_PATCH 66
 
-#define VERSION "26.6.65"
+#define VERSION "26.6.66"
 #define VERSION_DATE "2026-07-01"


### PR DESCRIPTION
A large, device-tested pass over AB/track creation and guidance-line display. Client + a few backend/pipeline changes.

## Quick AB — one creation hub
Consolidated the two menus (Quick AB + Draw-Track-on-Map) into a single **Quick AB** dialog with three sections, and removed the separate dialog + its bottom-nav launchers:
- **By Driving:** A+ · Drive AB · Curve
- **From Field Boundary:** Longest Edge · Bnd. Curve · All Edges
- **Draw on Map:** Straight · Curve

## Creation flows
- **Drive AB:** A/B markers drop at the vehicle; button steps **Set Point A → Set Point B**; B shows a beat, then the line is created.
- **Drive Curve:** **Set Point A** starts recording, green path dots drop as you drive, **Set Point B** finishes; labelled A/B endpoints.
- **Straight/curve draw:** A/B letter rides the crosshair (**mouse only**) + orange-A / blue-B labelled dots at the tapped points.
- **Bnd. Curve:** tap A then B on the boundary → curve along the **shorter arc**, **Chaikin-smoothed** corners, offset **half a tool inside** the fence. It drives **on** the boundary (`NoPassOffset`: no free-drive nearest-pass snap; laterals / nudge / manual U-turn still work). Persisted in the field GeoJSON.
- **A+:** client-side "needs a GPS position" hint (host was bailing silently).

## Touch fixes
- Crosshair A/B letter and the "Esc to cancel" hint are **mouse/keyboard only**.
- Flag placement (and any bare map-tap flow) gets a touch **Cancel** pill.

## Guidance-line rendering
- Purple **reference drawn only when offset** (pass ≠ 0); on the reference pass you see one clean magenta line. Both **extended full-field** (fixes the short-stub offset line).
- **1-based pass label** ("Pass 1" = the reference line). New `PassNumber` on the Tick drives both.

## Known limitation (follow-up)
**Auto-U-turns on a boundary curve** are stop-gapped **off** (they arm off headland proximity and mis-fire on a boundary-hugging line). Drive + lateral + manual U-turn work. Proper end-of-pass auto-U-turn geometry is a separate branch.

## Testing
Services (1025) + ViewModels (222) suites pass; Desktop builds clean. Extensively device-tested on the tablet across all the flows above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)