### PR TITLE
Boundary-curve auto-U-turns: work a field pass-by-pass following the fence

### DIFF
--- a/Shared/AgOpenWeb.Models/Guidance/CurveProcessing.cs
+++ b/Shared/AgOpenWeb.Models/Guidance/CurveProcessing.cs
@@ -426,6 +426,17 @@ namespace AgOpenWeb.Models.Guidance
                 }, skippedCount * 100.0 / refCount);
             }
 
+            // Collision removal at a tight inward bend (e.g. a boundary curve wrapping a field
+            // end) deletes the colliding inner-corner points, leaving a straight chord across
+            // the gap that renders as a SHARP corner — unlike the reference pass, which is
+            // rounded. Round that chord back out with one Chaikin pass so an offset pass and its
+            // cyan next-track match the reference's smoothness. Gated on removal so gentle curves
+            // (nothing skipped) are untouched; endpoints are preserved so the track→turn handoff
+            // and the boundary extension stay put. Both the displayed guidance line and the U-turn
+            // generator build from this same routine, so they stay byte-for-byte matched.
+            if (skippedCount > 0 && offsetPoints.Count > 2)
+                offsetPoints = ChaikinsSmooth(offsetPoints, 1);
+
             // Recalculate headings based on actual offset point positions
             CalculateHeadings(offsetPoints);
 

--- a/Shared/AgOpenWeb.RemoteServer/wwwroot/app.js
+++ b/Shared/AgOpenWeb.RemoteServer/wwwroot/app.js
@@ -3483,7 +3483,11 @@ const hlHud = document.getElementById('headland-hud');
 function updateHeadlandHud() {
   const on = config && config.display && config.display.headlandDistanceVisible;
   const d = tick ? tick.headlandDist : -1;
-  if (!on || d == null || d < 0) { hlHud.style.display = 'none'; return; }
+  // Hide the HUD while a map-tap creation flow is active (Quick AB / boundary curve / draw / …):
+  // the boundary distance isn't needed while placing points, and it would clutter the top-centre
+  // instruction pill + toolbar. body.maptap is set by startMapTap for the duration of the flow.
+  const creating = document.body.classList.contains('maptap');
+  if (!on || creating || d == null || d < 0) { hlHud.style.display = 'none'; return; }
   const metric = !statusBar || statusBar.isMetric;
   hlHud.textContent = metric ? d.toFixed(1) + ' m' : (d * 3.28084).toFixed(0) + ' ft';
   hlHud.classList.toggle('warn', !!(tick && tick.headlandWarn));

--- a/Shared/AgOpenWeb.RemoteServer/wwwroot/index.html
+++ b/Shared/AgOpenWeb.RemoteServer/wwwroot/index.html
@@ -143,7 +143,9 @@
     }
     /* Headland-distance HUD — screen-space box at top-centre (below the light bar),
        mirroring the native SkiaMapControl HUD. Green when clear, red on warning.
-       Gated by Display.HeadlandDistanceVisible + a live distance ≥ 0. */
+       Gated by Display.HeadlandDistanceVisible + a live distance ≥ 0, AND hidden while a
+       map-tap creation flow is active (updateHeadlandHud) so it doesn't clutter the top-centre
+       instruction pill / draw toolbar. */
     #headland-hud {
       position: fixed; top: calc(102px + var(--sat)); left: 50%; transform: translateX(-50%); display: none;
       padding: 6px 18px; border-radius: 8px; border: 1px solid rgba(var(--ov),0.25);
@@ -186,7 +188,7 @@
       text-shadow: 0 0 3px #000, 0 1px 5px rgba(0,0,0,0.95); }
     /* Draw-track toolbar (Phase MT) — top-centre, directly under the instruction pill
        (#maptap-hint at top:60px) so the action buttons sit with the prompt, not across
-       the screen from it. */
+       the screen from it. (The distance HUD is hidden during these flows — updateHeadlandHud.) */
     #draw-toolbar {
       position: fixed; top: calc(100px + var(--sat)); left: 50%; transform: translateX(-50%); display: none;
       gap: 10px; z-index: 41;
@@ -2476,8 +2478,8 @@
              (cycle/smooth/delete + nudges), shown only with an active track (.bn-abdep). -->
         <div class="bn-flyrow">
           <button class="bn-btn" id="bn-tracks" title="Tracks — manage AB lines"><img class="bn-ic" src="/icons/ABTracks.png" alt="Tracks"></button>
-          <button class="bn-btn" id="bn-autotrack" data-cmd="track.autoTrack" data-t2 title="Auto track select (closest track)">AT</button>
           <button class="bn-btn" id="bn-quickab" title="Quick AB line creator"><img class="bn-ic" src="/icons/ABTrackAPlus.png" alt="Quick AB"></button>
+          <button class="bn-btn" id="bn-autotrack" data-cmd="track.autoTrack" data-t2 title="Auto track select (closest track)">AT</button>
         </div>
         <div class="bn-flysep bn-abdep"></div>
         <div class="bn-flyrow bn-abdep">

--- a/Shared/AgOpenWeb.Services/Pipeline/GpsPipelineService.cs
+++ b/Shared/AgOpenWeb.Services/Pipeline/GpsPipelineService.cs
@@ -525,12 +525,15 @@ public sealed class GpsPipelineService : IGpsPipelineService
         // nudges and U-turns still change the pass normally; we don't pin it here.
         bool noPassOffset = track != null && track.NoPassOffset;
 
-        // No-headland workflow: substitute a synthetic headland line that
-        // sits one (turn radius + UTurnDistanceFromBoundary) inset from the
-        // outer boundary, so the auto-uturn arc's apex lands inside the
-        // outer boundary. headlandCalculatedWidth is set to the inset so
-        // downstream U-turn geometry (HeadlandWidth, leg lengths) is
-        // consistent with the synthesized line.
+        // No-headland workflow: substitute the outer-boundary TURN LINE for the
+        // missing headland line — the AgOpen model (CTurn.BuildTurnLines): the
+        // fence offset inward by just UTurnDistanceFromBoundary. This line is the
+        // "in-turn-bounds" polygon the state machine gates arming on and raycasts
+        // distance to; a fence-hugging boundary-follow pass (offset ~half a tool
+        // inside the fence) sits INSIDE it, so it arms via the normal cultivated-
+        // zone path. The turn's actual geometry is anchored on the turn boundary
+        // built inside BuildCreationInput (also offset by UTurnDistanceFromBoundary)
+        // and fitted by MoveTurnInsideTurnLine, so this line does not shape the arc.
         if (headlandLine == null && boundary?.OuterBoundary != null && boundary.OuterBoundary.IsValid)
         {
             var synth = GetOrComputeSyntheticHeadland(boundary);
@@ -1594,13 +1597,13 @@ public sealed class GpsPipelineService : IGpsPipelineService
     private (List<Vec3>? Line, double Inset) GetOrComputeSyntheticHeadland(Boundary boundary)
     {
         var guidanceConfig = _configStore.Guidance;
-        double turnRadius = guidanceConfig.UTurnRadius;
-        double distFromBoundary = guidanceConfig.UTurnDistanceFromBoundary;
-        double inset = turnRadius + distFromBoundary;
-        // Pack the two doubles into a single key. UTurnRadius is small (<20m)
-        // so multiplying by 1000 and adding distance keeps both contributions
-        // distinguishable for cache invalidation purposes.
-        double configKey = turnRadius * 1000.0 + distFromBoundary;
+        // AgOpen CTurn.BuildTurnLines: turn line = fence inset by uturnDistanceFromBoundary
+        // ONLY (no turn-radius inset). A deeper inset would push a fence-hugging boundary
+        // pass outside the "in-turn-bounds" polygon and it would never arm; the turn radius
+        // is accounted for by MoveTurnInsideTurnLine fitting the arc, not by pre-insetting
+        // this line.
+        double inset = guidanceConfig.UTurnDistanceFromBoundary;
+        double configKey = inset;
 
         if (ReferenceEquals(boundary, _syntheticHeadlandSourceBoundary)
             && Math.Abs(configKey - _syntheticHeadlandConfigKey) < 1e-9)
@@ -1618,8 +1621,8 @@ public sealed class GpsPipelineService : IGpsPipelineService
         _syntheticHeadlandSourceBoundary = boundary;
         _syntheticHeadlandConfigKey = configKey;
         _syntheticHeadlandInsetUsed = inset;
-        _logger.LogDebug("[YouTurn] Synthesized headland (no user headland): inset={I:F1}m (turnR={R:F1}+dist={D:F1}), pts={P}",
-            inset, turnRadius, distFromBoundary, _syntheticHeadlandLine?.Count ?? 0);
+        _logger.LogDebug("[YouTurn] Synthesized turn line (no user headland): inset={I:F1}m (uturnDistanceFromBoundary), pts={P}",
+            inset, _syntheticHeadlandLine?.Count ?? 0);
         return (_syntheticHeadlandLine, _syntheticHeadlandInsetUsed);
     }
 

--- a/Shared/AgOpenWeb.Services/YouTurn/YouTurnPathingService.cs
+++ b/Shared/AgOpenWeb.Services/YouTurn/YouTurnPathingService.cs
@@ -194,6 +194,19 @@ public sealed class YouTurnPathingService
         double widthMinusOverlap = config.ActualToolWidth - config.Tool.Overlap;
         double nextDistAway = widthMinusOverlap * nextPathsAway;
 
+        // Curves: sample the ACTUAL offset curve, not the straight A→B chord. An irregular
+        // boundary curve's chord can sit well off the real line, so the chord test picks the
+        // wrong side (the outward one, outside the fence — the "return path outside boundary"
+        // bug). Offsetting the real curve points is accurate for either direction.
+        if (currentTrack.Points.Count > 2)
+        {
+            var offsetCurve = CurveProcessing.CreateOffsetCurve(currentTrack.Points, nextDistAway);
+            foreach (var p in offsetCurve)
+                if (IsPointInsideCultivatedArea(p.Easting, p.Northing, boundary, headlandLine))
+                    return true;
+            return false;
+        }
+
         var pointA = currentTrack.Points[0];
         var pointB = currentTrack.Points[currentTrack.Points.Count - 1];
         double perpAngle = abHeading + Math.PI / 2;

--- a/Shared/AgOpenWeb.Services/YouTurn/YouTurnStateMachine.cs
+++ b/Shared/AgOpenWeb.Services/YouTurn/YouTurnStateMachine.cs
@@ -230,12 +230,18 @@ public sealed class YouTurnStateMachine
                 (currentPosition.Easting - turnStart.Easting) * (currentPosition.Easting - turnStart.Easting) +
                 (currentPosition.Northing - turnStart.Northing) * (currentPosition.Northing - turnStart.Northing));
 
-            // Publish current pivot→trigger distance for the UI countdown widget.
-            // Only meaningful while a precomputed turn-start exists and we haven't
-            // begun executing yet; once IsExecuting flips, the widget is expected
-            // to switch to a "turning" state and we revert to 0 (set above).
-            turn.DistanceToTrigger = distToTurnStart;
+            // Publish the pivot→trigger distance for the UI countdown widget as ARC LENGTH
+            // ALONG THE TRACK, not straight-line. On a curve that wraps a field end, the turn
+            // start can be far to the east while the tractor drives west around the wrap toward
+            // it — a Euclidean distance would COUNT UP as it drives away in a straight line, when
+            // the operator expects it to COUNT DOWN as the pass is worked. Falls back to the
+            // straight-line value for AB lines (2-point tracks) where the two are identical.
+            turn.DistanceToTrigger = track.Points.Count > 2
+                ? ArcLengthAlongTrack(track.Points, currentPosition, turnStart)
+                : distToTurnStart;
 
+            // Trigger on physical proximity (straight-line): the tractor must actually reach the
+            // turn start, regardless of how the arc-length display reads.
             if (distToTurnStart <= TriggerProximityMeters)
             {
                 turn.IsTriggered = true;
@@ -379,6 +385,43 @@ public sealed class YouTurnStateMachine
             remaining += Math.Sqrt(dx * dx + dy * dy);
         }
         return remaining;
+    }
+
+    /// <summary>
+    /// Arc length along <paramref name="track"/> between the point nearest
+    /// <paramref name="pivot"/> and the point nearest <paramref name="turnStart"/>. Gives a
+    /// "distance remaining as the pass is worked" that decreases as the tractor advances toward
+    /// the turn, even when the turn start is straight-line far away (a curve wrapping a field
+    /// end). Snaps both ends to the nearest track point, so the readout steps at roughly the
+    /// track point spacing (~2 m) — fine for a distance display.
+    /// </summary>
+    private static double ArcLengthAlongTrack(
+        IReadOnlyList<Vec3> track, Position pivot, Vec3 turnStart)
+    {
+        int NearestIdx(double e, double n)
+        {
+            int best = 0; double bestSq = double.MaxValue;
+            for (int i = 0; i < track.Count; i++)
+            {
+                double de = track[i].Easting - e, dn = track[i].Northing - n;
+                double d2 = de * de + dn * dn;
+                if (d2 < bestSq) { bestSq = d2; best = i; }
+            }
+            return best;
+        }
+
+        int pivotIdx = NearestIdx(pivot.Easting, pivot.Northing);
+        int turnIdx = NearestIdx(turnStart.Easting, turnStart.Northing);
+        int lo = Math.Min(pivotIdx, turnIdx), hi = Math.Max(pivotIdx, turnIdx);
+
+        double len = 0;
+        for (int i = lo; i < hi; i++)
+        {
+            double de = track[i + 1].Easting - track[i].Easting;
+            double dn = track[i + 1].Northing - track[i].Northing;
+            len += Math.Sqrt(de * de + dn * dn);
+        }
+        return len;
     }
 
     /// <summary>

--- a/Shared/AgOpenWeb.ViewModels/MainViewModel.Commands.Track.cs
+++ b/Shared/AgOpenWeb.ViewModels/MainViewModel.Commands.Track.cs
@@ -81,13 +81,16 @@ public partial class MainViewModel
             StatusMessage = "Load a field with a boundary first";
             return;
         }
-        // Offset the boundary inward by half the tool width so the curve sits half-an-implement
-        // inside the fence (following it keeps the whole implement in the field — #422, same as
-        // the whole-boundary curve). Fall back to the raw boundary if the offset fails.
-        double halfTool = ConfigStore.ActualToolWidth / 2.0;
+        // Offset the boundary inward by half the tool width PLUS half the U-turn clearance so the
+        // curve sits a half-implement inside the fence AND clears the turn line (which is
+        // UTurnDistanceFromBoundary inside) with margin — following it keeps the whole implement in
+        // the field (#422) while the pass stays inside the cultivated/turn zone. Fall back to the
+        // raw boundary if the offset fails.
+        double insetDistance = ConfigStore.ActualToolWidth / 2.0
+            + ConfigStore.Guidance.UTurnDistanceFromBoundary / 2.0;
         var rawVec2 = new System.Collections.Generic.List<Models.Base.Vec2>(boundary.Points.Count);
         foreach (var p in boundary.Points) rawVec2.Add(new Models.Base.Vec2(p.Easting, p.Northing));
-        var offset = halfTool > 0.05 ? _polygonOffsetService.CreateInwardOffset(rawVec2, halfTool) : null;
+        var offset = insetDistance > 0.05 ? _polygonOffsetService.CreateInwardOffset(rawVec2, insetDistance) : null;
         var ring = (offset != null && offset.Count >= 3) ? offset : rawVec2;
         int n = ring.Count;
 
@@ -122,7 +125,12 @@ public partial class MainViewModel
         // Round the boundary's sharp corners so the tractor can actually drive it (Chaikin
         // corner-cutting), then heading per point (guidance's forward test keys off it).
         var smoothed = Models.Guidance.CurveProcessing.ChaikinsSmooth(seg, 3);
-        var curvePoints = Models.Guidance.CurveProcessing.CalculateHeadings(smoothed);
+        var headed = Models.Guidance.CurveProcessing.CalculateHeadings(smoothed);
+        // Extend both ends past the field boundary along their tangents — exactly like the
+        // hand-drawn curve tool (ExtendCurvePastBoundary) and an AB line. Without this the curve
+        // stops inside the field and the U-turn generator has no boundary crossing to anchor the
+        // turn at each pass end; with it, the ends run past the fence and turns fire normally.
+        var curvePoints = ExtendCurvePastBoundary(headed);
         var track = new Models.Track.Track
         {
             Name = "Boundary Curve",
@@ -137,7 +145,7 @@ public partial class MainViewModel
         SavedTracks.Add(track);
         SelectedTrack = track;
         SaveTracksToFile();
-        StatusMessage = $"Created boundary curve ({curvePoints.Count} points, {halfTool:F1} m inside fence)";
+        StatusMessage = $"Created boundary curve ({curvePoints.Count} points, {insetDistance:F1} m inside fence)";
     }
 
     private void InitializeTrackCommands()
@@ -1624,14 +1632,42 @@ public partial class MainViewModel
             lastPoint.Northing + cosEnd2 * extendEnd,
             endHeading);
 
-        // Insert extended start at beginning, replace first point
-        result[0] = extendedStart;
-        // Append extended end, replace last point
-        result[^1] = extendedEnd;
+        // DENSIFY the extensions instead of replacing the endpoints with a single far point.
+        // A boundary curve's end can extend a very long way (e.g. its tangent runs along the
+        // fence, so the raycast lands on the OPPOSITE fence hundreds of metres away). Left as a
+        // lone 2-point segment, a tractor sitting on that long segment finds the far endpoint
+        // (index 0) as its nearest curve point — and FindCurveTurnPoint's walk (`j > 0`) can't
+        // advance from index 0, so it finds no crossing, the U-turn generator fails, and the
+        // straight-line fallback mis-plots the turn at whatever fence the travel-heading raycast
+        // hits (the "U-turn in the wrong corner" bug). Densified points keep the nearest index in
+        // the interior so the walk proceeds in either direction.
+        const double extSpacing = 2.0;
+        var densified = new List<Vec3>(result.Count + 64);
 
-        _logger.LogDebug($"[Curve] Extended start by {extendStart:F1}m, end by {extendEnd:F1}m");
+        int leadSteps = Math.Max(1, (int)(extendStart / extSpacing));
+        for (int i = 0; i < leadSteps; i++)
+        {
+            double f = (double)i / leadSteps; // 0 at extended tip → 1 at firstPoint (exclusive)
+            densified.Add(new Vec3(
+                extendedStart.Easting + (firstPoint.Easting - extendedStart.Easting) * f,
+                extendedStart.Northing + (firstPoint.Northing - extendedStart.Northing) * f,
+                startHeading));
+        }
+        densified.AddRange(result); // keeps the original first/last points and the curve body
 
-        return result;
+        int tailSteps = Math.Max(1, (int)(extendEnd / extSpacing));
+        for (int i = 1; i <= tailSteps; i++)
+        {
+            double f = (double)i / tailSteps; // firstPoint-after-last → extended tip
+            densified.Add(new Vec3(
+                lastPoint.Easting + (extendedEnd.Easting - lastPoint.Easting) * f,
+                lastPoint.Northing + (extendedEnd.Northing - lastPoint.Northing) * f,
+                endHeading));
+        }
+
+        _logger.LogDebug($"[Curve] Extended start by {extendStart:F1}m, end by {extendEnd:F1}m (densified)");
+
+        return densified;
     }
 
     /// <summary>

--- a/Shared/AgOpenWeb.ViewModels/MainViewModel.Commands.Track.cs
+++ b/Shared/AgOpenWeb.ViewModels/MainViewModel.Commands.Track.cs
@@ -1399,38 +1399,57 @@ public partial class MainViewModel
             }
 
             var pts = boundary.Points;
-            int created = 0;
-            for (int i = 0; i < pts.Count; i++)
+            int n = pts.Count;
+
+            // Boundary points are densified along each straight edge, so one AB line PER POINT
+            // would make dozens on a 4-sided field. Find the CORNERS instead — vertices where the
+            // boundary direction turns sharply — and make one AB line per edge between corners.
+            const double CornerTurnThreshold = 0.35; // ~20°: real corners turn ~90°, edge noise <5°
+            var corners = new System.Collections.Generic.List<int>();
+            for (int i = 0; i < n; i++)
             {
-                int next = (i + 1) % pts.Count;
-                double dx = pts[next].Easting - pts[i].Easting;
-                double dy = pts[next].Northing - pts[i].Northing;
-                double dist = Math.Sqrt(dx * dx + dy * dy);
+                var prev = pts[(i - 1 + n) % n];
+                var cur = pts[i];
+                var nxt = pts[(i + 1) % n];
+                double hIn = Math.Atan2(cur.Easting - prev.Easting, cur.Northing - prev.Northing);
+                double hOut = Math.Atan2(nxt.Easting - cur.Easting, nxt.Northing - cur.Northing);
+                double turn = hOut - hIn;
+                while (turn > Math.PI) turn -= 2 * Math.PI;
+                while (turn < -Math.PI) turn += 2 * Math.PI;
+                if (Math.Abs(turn) > CornerTurnThreshold) corners.Add(i);
+            }
 
-                if (dist < 5.0) continue; // Skip tiny edges
-
-                double heading = Math.Atan2(dx, dy);
-                var a = new Models.Base.Vec3(
-                    pts[i].Easting - Math.Sin(heading) * 50,
-                    pts[i].Northing - Math.Cos(heading) * 50, heading);
-                var b = new Models.Base.Vec3(
-                    pts[next].Easting + Math.Sin(heading) * 50,
-                    pts[next].Northing + Math.Cos(heading) * 50, heading);
-
-                var track = new Models.Track.Track
+            int created = 0;
+            if (corners.Count >= 2)
+            {
+                // One AB line per edge: from each corner to the next, extended 50 m past both.
+                for (int k = 0; k < corners.Count; k++)
                 {
-                    Name = $"Edge {i + 1} ({dist:F0}m)",
-                    Points = new System.Collections.Generic.List<Models.Base.Vec3> { a, b },
-                    Type = Models.Track.TrackType.ABLine,
-                    IsVisible = true
-                };
-                SavedTracks.Add(track);
-                created++;
+                    var pa = pts[corners[k]];
+                    var pb = pts[corners[(k + 1) % corners.Count]];
+                    double dx = pb.Easting - pa.Easting, dy = pb.Northing - pa.Northing;
+                    double dist = Math.Sqrt(dx * dx + dy * dy);
+                    if (dist < 5.0) continue;
+
+                    double heading = Math.Atan2(dx, dy);
+                    var a = new Models.Base.Vec3(pa.Easting - Math.Sin(heading) * 50, pa.Northing - Math.Cos(heading) * 50, heading);
+                    var b = new Models.Base.Vec3(pb.Easting + Math.Sin(heading) * 50, pb.Northing + Math.Cos(heading) * 50, heading);
+                    SavedTracks.Add(new Models.Track.Track
+                    {
+                        Name = $"Edge {created + 1} ({dist:F0}m)",
+                        Points = new System.Collections.Generic.List<Models.Base.Vec3> { a, b },
+                        Type = Models.Track.TrackType.ABLine,
+                        IsVisible = true
+                    });
+                    created++;
+                }
             }
 
             if (created > 0)
                 SelectedTrack = SavedTracks[SavedTracks.Count - 1];
-            StatusMessage = $"Created {created} AB lines from boundary edges";
+            StatusMessage = created > 0
+                ? $"Created {created} AB lines from boundary edges"
+                : "Could not detect distinct boundary edges";
         });
 
         // Map zoom commands

--- a/Shared/AgOpenWeb.ViewModels/MainViewModel.GpsHandling.cs
+++ b/Shared/AgOpenWeb.ViewModels/MainViewModel.GpsHandling.cs
@@ -417,10 +417,13 @@ public partial class MainViewModel
         _gpsPipelineService.SetHeadlandLine(State.Field.HeadlandLine);
         _gpsPipelineService.SetDriftCompensation(State.Field.DriftEasting, State.Field.DriftNorthing);
         // Never arm U-turns on a closed/polygon track, regardless of the toggle (#421).
-        // Stopgap: also skip auto-U-turns on a boundary-follow (NoPassOffset) curve — auto
-        // arming is headland-proximity based and mis-fires on a line that hugs the boundary
-        // (fires at the first corner, return path outside the fence). Manual U-turns still work.
-        // Proper end-of-pass auto-U-turns for boundary curves are a separate follow-up.
+        // Stopgap: auto-U-turns are OFF on a boundary-follow (NoPassOffset) curve. Root cause:
+        // the arc only creates when the tractor is in the cultivated area (inside the headland
+        // line — synthetic when none defined, inset several m from the fence), but a fence-
+        // hugging pass sits INSIDE that band → never "cultivated" → no arc, it drives off the
+        // end. Proper fix = arm off the outer boundary / end-of-pass when there's no real
+        // headland. See continuation memory [[project_boundary_curve_uturn_continuation]].
+        // Manual U-turns + laterals still work on the boundary curve.
         _gpsPipelineService.SetYouTurnEnabled(
             IsYouTurnEnabled && !IsActiveTrackClosed && !(SelectedTrack?.NoPassOffset == true));
         _gpsPipelineService.SetYouTurnConfig(

--- a/Shared/AgOpenWeb.ViewModels/MainViewModel.GpsHandling.cs
+++ b/Shared/AgOpenWeb.ViewModels/MainViewModel.GpsHandling.cs
@@ -417,15 +417,7 @@ public partial class MainViewModel
         _gpsPipelineService.SetHeadlandLine(State.Field.HeadlandLine);
         _gpsPipelineService.SetDriftCompensation(State.Field.DriftEasting, State.Field.DriftNorthing);
         // Never arm U-turns on a closed/polygon track, regardless of the toggle (#421).
-        // Stopgap: auto-U-turns are OFF on a boundary-follow (NoPassOffset) curve. Root cause:
-        // the arc only creates when the tractor is in the cultivated area (inside the headland
-        // line — synthetic when none defined, inset several m from the fence), but a fence-
-        // hugging pass sits INSIDE that band → never "cultivated" → no arc, it drives off the
-        // end. Proper fix = arm off the outer boundary / end-of-pass when there's no real
-        // headland. See continuation memory [[project_boundary_curve_uturn_continuation]].
-        // Manual U-turns + laterals still work on the boundary curve.
-        _gpsPipelineService.SetYouTurnEnabled(
-            IsYouTurnEnabled && !IsActiveTrackClosed && !(SelectedTrack?.NoPassOffset == true));
+        _gpsPipelineService.SetYouTurnEnabled(IsYouTurnEnabled && !IsActiveTrackClosed);
         _gpsPipelineService.SetYouTurnConfig(
             UTurnSkipRows, IsSkipWorkedMode, HeadlandCalculatedWidth, HeadlandDistance);
     }

--- a/Tests/AgOpenWeb.Services.Tests/YouTurn/BoundaryPassArmingTests.cs
+++ b/Tests/AgOpenWeb.Services.Tests/YouTurn/BoundaryPassArmingTests.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using AgOpenWeb.Models;
+using AgOpenWeb.Models.Base;
+using AgOpenWeb.Models.Configuration;
+using AgOpenWeb.Models.Pipeline;
+using AgOpenWeb.Models.State;
+using AgOpenWeb.Services.Geometry;
+using AgOpenWeb.Services.YouTurn;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+
+namespace AgOpenWeb.Services.Tests.YouTurn;
+
+/// <summary>
+/// Auto-U-turn arming on a fence-hugging boundary-follow pass in a field with NO real
+/// headland. The turn line is the AgOpen model: fence inset by uturnDistanceFromBoundary
+/// only (NOT turn-radius + distance). A pass offset ~half a tool width inside the fence
+/// therefore sits INSIDE the turn line → the tractor reads as "in the cultivated / in-turn
+/// area" → it arms through the ordinary path, no special-casing. This is the regression
+/// guard for the old bug where the synthetic line was inset by turnRadius + distance (~10 m),
+/// which put the boundary pass permanently OUTSIDE the band so it never armed.
+/// </summary>
+[TestFixture]
+[NonParallelizable]
+public class BoundaryPassArmingTests
+{
+    private const double ToolWidth = 6.0;
+    private const double HalfTool = ToolWidth / 2.0;
+    private const double DistFromBoundary = 2.0;
+
+    private YouTurnStateMachine _sm = null!;
+    private Boundary _boundary = null!;
+    private List<Vec3> _turnLine = null!;
+    private Models.Track.Track _track = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        ConfigurationStore.SetInstance(new ConfigurationStore());
+        var c = ConfigurationStore.Instance;
+        c.Vehicle.Wheelbase = 2.5;
+        c.Vehicle.MaxSteerAngle = 35;
+        c.Tool.Overlap = 0;
+        c.NumSections = 1;
+        c.Tool.SetSectionWidth(0, (int)(ToolWidth * 100)); // 6 m
+        c.Guidance.UTurnRadius = 8.0;
+        c.Guidance.UTurnExtension = 16.0;
+        c.Guidance.UTurnDistanceFromBoundary = DistFromBoundary;
+        c.Guidance.UTurnStyle = 0;
+
+        var offset = new PolygonOffsetService();
+        var creation = new YouTurnCreationService(NullLogger<YouTurnCreationService>.Instance, offset, c);
+        var pathing = new YouTurnPathingService(NullLogger<YouTurnPathingService>.Instance, c);
+        _sm = new YouTurnStateMachine(creation, pathing, NullLogger<YouTurnStateMachine>.Instance, c);
+
+        // 100 x 100 m field, fence at ±50.
+        var outer = new List<Vec2> { new(-50, -50), new(50, -50), new(50, 50), new(-50, 50) };
+        _boundary = new Boundary
+        {
+            OuterBoundary = new BoundaryPolygon
+            {
+                Points = outer.Select(p => new BoundaryPoint(p.Easting, p.Northing, 0)).ToList(),
+            },
+        };
+
+        // Turn line as the pipeline now builds it: fence inset by uturnDistanceFromBoundary
+        // = 2 m → square at ±48. (Pre-fix it was inset by 10 m → ±40, which excluded the pass.)
+        _turnLine = offset.CalculatePointHeadings(
+            offset.CreateInwardOffset(outer, DistFromBoundary)!);
+
+        // Fence-hugging boundary-follow pass along the WEST fence: x = -50 + halfTool = -47,
+        // heading due north. Inside the ±48 turn line (x = -47 > -48).
+        var curve = new List<Vec3>();
+        for (double y = -46; y <= 46 + 1e-9; y += 2.0)
+            curve.Add(new Vec3(-50 + HalfTool, y, 0));
+        _track = Models.Track.Track.FromCurve("bnd pass", curve);
+        _track.NoPassOffset = true;
+    }
+
+    private YouTurnStateMachine.TickContext MakeContext(double easting, double northing, double headingDeg)
+    {
+        var pos = new Position
+        {
+            Easting = easting,
+            Northing = northing,
+            Heading = headingDeg,
+            Speed = 2.78,
+        };
+        return new YouTurnStateMachine.TickContext(
+            pos, _track, _boundary, _turnLine,
+            UTurnSkipRows: 0, IsSkipWorkedMode: false,
+            HeadlandCalculatedWidth: DistFromBoundary, HeadlandDistance: 5.0);
+    }
+
+    [Test]
+    public void FenceHuggingPass_IsInsideTurnLine_AndArms()
+    {
+        var gState = new GuidanceWorkingState();
+        var tState = new YouTurnWorkingState { IsEnabled = true };
+
+        // Mid-pass, heading north along the west fence.
+        var ctx = MakeContext(-47, -20, 0);
+
+        List<Vec3>? armed = null;
+        for (int i = 0; i < 8 && armed == null; i++)
+        {
+            tState.YouTurnCounter++;
+            _sm.Tick(in ctx, gState, tState);
+            armed = tState.TurnPath;
+        }
+
+        Assert.That(tState.CurrentZone, Is.EqualTo(TractorZone.InCultivatedArea),
+            "the fence-hugging pass must read as inside the turn line (in-turn-bounds)");
+        Assert.That(armed, Is.Not.Null, "turn must arm through the normal cultivated-zone path");
+        Assert.That(armed!.Count, Is.GreaterThan(10));
+
+        // The next pass must be INWARD (east of the fence pass, toward the field).
+        Assert.That(tState.NextTrack, Is.Not.Null);
+        double avgNextEasting = tState.NextTrack!.Points.Average(p => p.Easting);
+        Assert.That(avgNextEasting, Is.GreaterThan(-47.0 + 1.0),
+            "next track must land on the inward side of the boundary pass");
+    }
+}

--- a/sys/version.h
+++ b/sys/version.h
@@ -5,7 +5,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 6
-#define VERSION_PATCH 66
+#define VERSION_PATCH 67
 
-#define VERSION "26.6.66"
+#define VERSION "26.6.67"
 #define VERSION_DATE "2026-07-01"

--- a/sys/version.h
+++ b/sys/version.h
@@ -5,7 +5,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 6
-#define VERSION_PATCH 67
+#define VERSION_PATCH 68
 
-#define VERSION "26.6.67"
-#define VERSION_DATE "2026-07-01"
+#define VERSION "26.6.68"
+#define VERSION_DATE "2026-07-02"

--- a/sys/version.h
+++ b/sys/version.h
@@ -5,7 +5,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 6
-#define VERSION_PATCH 68
+#define VERSION_PATCH 69
 
-#define VERSION "26.6.68"
+#define VERSION "26.6.69"
 #define VERSION_DATE "2026-07-02"


### PR DESCRIPTION
Makes the **Bnd. Curve** (boundary-follow curve) behave like any other curve — work the field pass-by-pass following the fence, with automatic U-turns — in fields with **no headland**. Device-verified on a real field (16 m tool, curve wrapping the west end).

## What was broken
Auto-U-turns never armed on a boundary-follow curve: the pipeline substituted a synthetic "headland" inset a full turn-radius from the fence, so the fence-hugging pass sat *outside* that band and never read as cultivated. Auto-U-turns were stop-gapped off.

## Fixes
- **Arming** — substitute the outer-boundary *turn line* (fence inset by `UTurnDistanceFromBoundary`, matching AgOpen `CTurn.BuildTurnLines`) for the missing headland, so the pass arms and turns through the ordinary curve path. Stopgap removed.
- **End extension** — the Bnd. Curve extends its ends past the fence like the hand-drawn curve tool (`ExtendCurvePastBoundary`), now **densified** at 2 m rather than a single far endpoint. A lone long segment made the tractor's nearest point land on index 0, which `FindCurveTurnPoint`'s walk can't advance from → generator failed → straight-line fallback mis-plotted the turn at the opposite fence (the "U-turn in the wrong corner" bug). *Root-caused against the operator's real field data.*
- **Corner rounding** — round offset-curve corners (one Chaikin pass, gated on collision removal) so offset passes and the cyan next-track match the reference at a tight wrap. Same routine feeds the display and the turn generator, so they stay matched (no handoff step).
- **Inset** — create the curve at `halfTool + UTurnDistanceFromBoundary/2` so it clears the turn line with margin.

## UX polish (same branch)
- Distance-to-U-turn readout counts **down** along the track (arc length), not straight-line — so a wrapping pass no longer counts up while driving away.
- **All Edges** detects boundary corners and builds one AB line per edge (a 4-sided field made ~45 lines; now 4).
- Menu: Quick-AB button moved next to Tracks; hide the distance HUD during map-tap creation flows.

## Notes
- Existing saved Bnd. Curves hold the old single-segment extension — re-create them to pick up the densified extension.
- Latent (not fixed, low risk): `FindCurveTurnPoint`'s `j>0` guard still can't walk from index 0; densification keeps the nearest index interior.

All tests green (Models 146 / Services 1026+2 skip / VM 222). v26.6.69.

🤖 Generated with [Claude Code](https://claude.com/claude-code)