### PR TITLE
Release v26.6.69

### DIFF
--- a/Shared/AgOpenWeb.Models/GeoJson/GeoJsonModels.cs
+++ b/Shared/AgOpenWeb.Models/GeoJson/GeoJsonModels.cs
@@ -89,6 +89,7 @@ public static class FieldPropertyKeys
     public const string Name = "name";
     public const string TrackType = "trackType";
     public const string IsClosed = "isClosed";
+    public const string NoPassOffset = "noPassOffset";
     public const string NudgeDistance = "nudgeDistance";
     public const string IsVisible = "isVisible";
     public const string IsDriveThrough = "isDriveThrough";

--- a/Shared/AgOpenWeb.Models/Guidance/CurveProcessing.cs
+++ b/Shared/AgOpenWeb.Models/Guidance/CurveProcessing.cs
@@ -426,6 +426,17 @@ namespace AgOpenWeb.Models.Guidance
                 }, skippedCount * 100.0 / refCount);
             }
 
+            // Collision removal at a tight inward bend (e.g. a boundary curve wrapping a field
+            // end) deletes the colliding inner-corner points, leaving a straight chord across
+            // the gap that renders as a SHARP corner — unlike the reference pass, which is
+            // rounded. Round that chord back out with one Chaikin pass so an offset pass and its
+            // cyan next-track match the reference's smoothness. Gated on removal so gentle curves
+            // (nothing skipped) are untouched; endpoints are preserved so the track→turn handoff
+            // and the boundary extension stay put. Both the displayed guidance line and the U-turn
+            // generator build from this same routine, so they stay byte-for-byte matched.
+            if (skippedCount > 0 && offsetPoints.Count > 2)
+                offsetPoints = ChaikinsSmooth(offsetPoints, 1);
+
             // Recalculate headings based on actual offset point positions
             CalculateHeadings(offsetPoints);
 

--- a/Shared/AgOpenWeb.Models/Track/Track.cs
+++ b/Shared/AgOpenWeb.Models/Track/Track.cs
@@ -91,6 +91,13 @@ public class Track : INotifyPropertyChanged
     public bool IsClosed { get; set; }
 
     /// <summary>
+    /// Drive this track directly (pass 0) instead of free-drive snapping to the nearest
+    /// parallel pass. Set for boundary-follow curves — you drive the boundary itself, not
+    /// offset passes of it. The guidance keeps the reference line, no pass offsetting.
+    /// </summary>
+    public bool NoPassOffset { get; set; }
+
+    /// <summary>
     /// Whether this track is currently active for guidance.
     /// </summary>
     private bool _isActive;

--- a/Shared/AgOpenWeb.RemoteServer/Contracts.cs
+++ b/Shared/AgOpenWeb.RemoteServer/Contracts.cs
@@ -157,7 +157,11 @@ public record TickDto(
     // U-turn/Lateral buttons with a hint during this window — snapping/turning mid-arc is
     // ignored by the pipeline (would move the displayed track while the tractor stays
     // committed to the current arc). Mirrors YouTurnState.IsExecuting (issue #50).
-    bool IsYouTurnExecuting);
+    bool IsYouTurnExecuting,
+    // Current guidance pass offset from the reference (HowManyPathsAway; 0 = on the reference
+    // line). The client draws the purple reference only when this is non-zero (on pass 0 it
+    // would overlap the magenta), and shows a 1-based pass label.
+    int PassNumber);
 
 /// <summary>Top status-bar readouts (Phase 1), sent at a low rate. GPS fix quality
 /// + correction age + sat count; the units preference (so the client formats speed

--- a/Shared/AgOpenWeb.RemoteServer/SceneProjector.cs
+++ b/Shared/AgOpenWeb.RemoteServer/SceneProjector.cs
@@ -310,7 +310,8 @@ public sealed class SceneProjector
                 ? v.RenderPoseMs
                 : System.Diagnostics.Stopwatch.GetTimestamp() * 1000.0 / System.Diagnostics.Stopwatch.Frequency,
             // Mid-turn gate (issue #50): true while the u-turn arc is executing.
-            _state.YouTurn.IsExecuting);
+            _state.YouTurn.IsExecuting,
+            _state.Guidance.HowManyPathsAway); // pass offset (0 = on reference) — #reference/label
     }
 
     // Top status-bar readouts (Phase 1). All state-projected: fix/age/sats from

--- a/Shared/AgOpenWeb.RemoteServer/WireCodec.cs
+++ b/Shared/AgOpenWeb.RemoteServer/WireCodec.cs
@@ -514,6 +514,7 @@ public static class WireCodec
         w.Write((float)t.VehicleSteerAngle); // front-wheel sprite angle (deg)
         w.Write(t.HostMs);           // f64 — host monotonic build time (client interp timeline)
         w.Write((byte)(t.IsYouTurnExecuting ? 1 : 0)); // #50 — mid-turn gate for on-screen buttons
+        w.Write(t.PassNumber);       // i32 — guidance pass offset (0 = on reference)
         return ms.ToArray();
     }
 

--- a/Shared/AgOpenWeb.RemoteServer/wwwroot/app.js
+++ b/Shared/AgOpenWeb.RemoteServer/wwwroot/app.js
@@ -565,7 +565,11 @@ addEventListener('pointerup', e => {
   gestureOnMap = false;
 });
 addEventListener('pointermove', e => {
-  if (mapTap && (abFlow === 'straight' || abFlow === 'curve')) updateAbCursorLabel(e.clientX, e.clientY); // #40 A/B/… on crosshair
+  // #40: the crosshair letter is a MOUSE-hover affordance — only for a real pointer. On
+  // touch/pen there's no hover to ride, and a tap's micro-move would drop the "big A" under
+  // the finger/button and clash with the placed-dot label; touch relies on the dot letters
+  // + the "Tap Point A/B" banner instead.
+  if (mapTap && (abFlow === 'straight' || abFlow === 'curve') && e.pointerType === 'mouse') updateAbCursorLabel(e.clientX, e.clientY);
   if (editDragIdx >= 0 && editSession) {       // drag the grabbed handle
     const w = s2w(e.clientX, e.clientY);
     if (w) editSession.points[editDragIdx] = editSession.kind === 'headland' ? hlSnap(w.e, w.n) : { e: w.e, n: w.n };
@@ -595,11 +599,16 @@ function startMapTap(cfg) {
   document.body.classList.add('maptap'); // crosshair cursor (CSS)
   const h = document.getElementById('maptap-hint');
   h.textContent = cfg.hint || 'Tap the map'; h.classList.add('show');
+  // Touch cancel: only for bare flows (no draw toolbar) — flag placement. The AB/sat/headland
+  // flows show the toolbar whose own Cancel handles them, so don't double it up.
+  const tbUp = document.getElementById('draw-toolbar').classList.contains('show');
+  document.getElementById('maptap-cancel').classList.toggle('show', !tbUp);
 }
 function endMapTap() {
   mapTap = null;
   document.body.classList.remove('maptap');
   document.getElementById('maptap-hint').classList.remove('show');
+  document.getElementById('maptap-cancel').classList.remove('show'); // hide the touch-cancel pill
   if (abLabelEl) abLabelEl.classList.remove('show'); // #40 hide the A/B crosshair letter
   if (abDotLabelsEl) for (const s of abDotLabelsEl.children) s.style.display = 'none'; // + the dot letters
 }
@@ -1005,7 +1014,9 @@ document.getElementById('bn-abmenu').addEventListener('pointerdown', e => { e.st
 let drawMode = null;     // 'straight' | 'curve' (map-tap modes only) — drives the preview
 let drawPts = [];        // [{e,n}] captured so far — preview only (host holds the real list)
 let abFlow = null;       // 'straight' | 'curve' | 'driveAB' | 'recordCurve' | null
-let driveStep = 0;       // Drive-AB: 0 → next press sets A, 1 → next sets B
+let driveStep = 0;       // Drive-AB / record-curve step: 0 → next press sets A/Start, 1 → sets B/End
+let curveMarks = [];     // client-side path dots dropped while driving a record-curve (Set Start→End)
+let _lastCurveMark = null;
 const drawBar = document.getElementById('draw-toolbar');
 const hintEl = document.getElementById('maptap-hint');
 function abHint() {
@@ -1013,7 +1024,7 @@ function abHint() {
     case 'straight': return drawPts.length === 0 ? 'Tap Point A' : 'Tap Point B';
     case 'curve': return `Tap points (${drawPts.length}) — Finish when done`;
     case 'driveAB': return driveStep === 0 ? 'Drive to A, then Set Point' : 'Drive to B, then Set Point';
-    case 'recordCurve': return 'Driving curve — Finish when done';
+    case 'recordCurve': return driveStep === 0 ? 'Drive to A, then Set Point A' : 'Drive the curve to B, then Set Point B';
   }
   return '';
 }
@@ -1044,7 +1055,7 @@ function updateAbCursorLabel(x, y) {
 // frame from drawPts (world→screen); cleared when the draw ends. DOM (CanvasKit has no text).
 function renderAbDotLabels() {
   if (!abDotLabelsEl) return;
-  const n = (drawMode && drawPts.length) ? drawPts.length : 0;
+  const n = drawPts.length || 0; // letters for map-tap AND Drive-AB markers (drawMode may be null)
   while (abDotLabelsEl.children.length < n) abDotLabelsEl.appendChild(document.createElement('span'));
   for (let i = 0; i < abDotLabelsEl.children.length; i++) {
     const span = abDotLabelsEl.children[i];
@@ -1071,16 +1082,43 @@ function startDrawTrack(mode) {           // map-tap straight/curve (ungated —
   startMapTap({ hint: abHint(), onTap: drawTap });
 }
 function startDriveAB() {                  // GPS: set A then B at the vehicle (ungated)
-  abFlow = 'driveAB'; driveStep = 0;
+  abFlow = 'driveAB'; driveStep = 0; drawPts = []; // drawPts holds the dropped A/B markers
   transport.send('track.driveAB');
   showAbBar(true, false, false);
+  document.getElementById('draw-setpoint').textContent = 'Set Point A';
   hintEl.classList.add('show'); setAbHint();
 }
-function startRecordCurve() {              // GPS: record by driving (ungated)
-  abFlow = 'recordCurve';
-  transport.send('track.recordCurve');
-  showAbBar(false, false, true);
+function startRecordCurve() {              // GPS: record by driving — Set Start → Set End (ungated)
+  abFlow = 'recordCurve'; driveStep = 0; curveMarks = []; _lastCurveMark = null;
+  // Recording doesn't begin until "Set Start" (deferred track.recordCurve), so the operator
+  // can position at the curve's start first. The set-point button drives the two-step.
+  showAbBar(true, false, false);
+  document.getElementById('draw-setpoint').textContent = 'Set Point A';
   hintEl.classList.add('show'); setAbHint();
+}
+// "Bnd. Curve" — tap point A then point B on the boundary; the host walks the shorter arc
+// between them and builds a curve following the boundary. Points snap to the nearest boundary
+// vertex for display; the host re-snaps authoritatively.
+function nearestBoundaryPt(e, n) {
+  let best = null, bd = Infinity;
+  const bs = scene && scene.boundaries;
+  if (bs) for (const ring of bs) for (const p of ring) {
+    const dx = p.e - e, dy = p.n - n, d = dx * dx + dy * dy;
+    if (d < bd) { bd = d; best = p; }
+  }
+  return best ? { e: best.e, n: best.n } : { e, n };
+}
+function startBoundaryCurve() {
+  abFlow = 'boundaryCurve'; drawPts = [];
+  showAbBar(false, false, false);          // draw toolbar shows just Cancel
+  startMapTap({ hint: 'Tap point A on the boundary', onTap: boundaryCurveTap });
+}
+function boundaryCurveTap(e, n) {
+  drawPts.push(nearestBoundaryPt(e, n));   // snap A/B to the nearest boundary vertex (dot shown)
+  if (drawPts.length < 2) { hintEl.textContent = 'Tap point B on the boundary'; return; }
+  const a = drawPts[0], b = drawPts[1];
+  transport.send('track.boundaryCurveSeg|' + a.e.toFixed(3) + ',' + a.n.toFixed(3) + ',' + b.e.toFixed(3) + ',' + b.n.toFixed(3));
+  endAbFlow();
 }
 function drawTap(e, n) {                    // map-tap point captured (straight/curve)
   drawPts.push({ e, n });
@@ -1089,11 +1127,35 @@ function drawTap(e, n) {                    // map-tap point captured (straight/
   if (abFlow === 'straight' && drawPts.length >= 2) { endAbFlow(); return; }
   setAbHint();
 }
-function abSetPoint() {                     // Drive-AB "Set Point" press
-  if (abFlow !== 'driveAB') return;
-  transport.send('track.setABGps');        // SetABPoint uses live GPS in DriveAB mode
-  if (driveStep === 0) { driveStep = 1; setAbHint(); }
-  else endAbFlow();                        // B set → host created the line
+function abSetPoint() {                     // Set-point button — drives Drive-AB and record-curve
+  const btn = document.getElementById('draw-setpoint');
+  if (abFlow === 'driveAB') {
+    if (driveStep > 1) return;             // guard a double-B while B lingers
+    transport.send('track.setABGps');      // SetABPoint uses live GPS in DriveAB mode
+    // Drop an A/B marker at the vehicle so the operator sees where each point landed.
+    if (tick && tick.pose) drawPts.push({ e: tick.pose.e, n: tick.pose.n });
+    if (driveStep === 0) { driveStep = 1; btn.textContent = 'Set Point B'; setAbHint(); }
+    else {                                  // B set → host created the line; show B a beat, then clear
+      driveStep = 2;
+      setTimeout(() => { if (abFlow === 'driveAB') endAbFlow(); }, 700);
+    }
+  } else if (abFlow === 'recordCurve') {
+    if (driveStep > 1) return;              // guard a double-B while B lingers
+    if (driveStep === 0) {                  // Set Point A → drop the A endpoint + begin recording
+      transport.send('track.recordCurve');
+      driveStep = 1; btn.textContent = 'Set Point B';
+      if (tick && tick.pose) {
+        drawPts.push({ e: tick.pose.e, n: tick.pose.n });   // labeled "A" endpoint dot (orange)
+        _lastCurveMark = { e: tick.pose.e, n: tick.pose.n }; // seed green-dot spacing; no dot at A itself
+      }
+      setAbHint();
+    } else {                                // Set Point B → drop the B endpoint + finish
+      driveStep = 2;
+      if (tick && tick.pose) drawPts.push({ e: tick.pose.e, n: tick.pose.n }); // labeled "B" endpoint dot (blue)
+      transport.send('track.finishCurve');  // host builds the curve from its recorded points
+      setTimeout(() => { if (abFlow === 'recordCurve') endAbFlow(); }, 700);   // show B a beat, then clear
+    }
+  }
 }
 function abUndo() {
   if (abFlow !== 'curve' || !drawPts.length) return;
@@ -1114,9 +1176,30 @@ function abCancel() {
 }
 function endAbFlow() {
   abFlow = null; drawMode = null; drawPts = []; driveStep = 0;
+  curveMarks = []; _lastCurveMark = null; // clear record-curve path dots
   drawBar.classList.remove('show');
   endMapTap();
   hintEl.classList.remove('show');
+}
+// Drop a path dot every ~1.5 m while recording a drive-curve (between Set Point A and B), so
+// the operator sees the shape being captured. Visual only — the host records the real curve.
+function sampleCurveMark() {
+  if (abFlow !== 'recordCurve' || driveStep !== 1 || !tick || !tick.pose) return;
+  const p = tick.pose;
+  if (_lastCurveMark && Math.hypot(p.e - _lastCurveMark.e, p.n - _lastCurveMark.n) < 1.5) return;
+  _lastCurveMark = { e: p.e, n: p.n };
+  curveMarks.push(_lastCurveMark);
+}
+function drawCurveMarksSk(canvas) {
+  if (!curveMarks.length) return;
+  const rad = Math.max(3, 0.4 * pxPerM);
+  SKP.flagFill.setColor(ckColor('#39FF6A')); // recording green
+  for (const p of curveMarks) {
+    if (pw(p.e, p.n) < 1.0) continue; // behind the near plane
+    const xy = w2s(p.e, p.n);
+    canvas.drawCircle(xy[0], xy[1], rad, SKP.flagFill);
+    canvas.drawCircle(xy[0], xy[1], rad, SKP.flagOutline);
+  }
 }
 // ---- boundary draw-on-map (Phase MT) — native BoundaryMapDialog equivalent ----
 // Shows a Bing aerial underlay (satEnabled) and captures the boundary polygon by tapping
@@ -1264,31 +1347,35 @@ document.getElementById('draw-setpoint').addEventListener('pointerdown', e => { 
 document.getElementById('draw-undo').addEventListener('pointerdown', e => { e.preventDefault(); e.stopPropagation(); hlFlow ? hlUndo() : satBnd ? satUndo() : abUndo(); });
 document.getElementById('draw-finish').addEventListener('pointerdown', e => { e.preventDefault(); e.stopPropagation(); editSession ? saveEdit() : hlFlow ? endHeadlandDraw() : satBnd ? satFinish() : abFinish(); });
 document.getElementById('draw-cancel').addEventListener('pointerdown', e => { e.preventDefault(); e.stopPropagation(); editSession ? endEdit() : hlFlow ? endHeadlandDraw() : satBnd ? satCancel() : abCancel(); });
+// Touch cancel for bare map-tap flows (flag). stopPropagation so the pill isn't taken as a map tap.
+document.getElementById('maptap-cancel').addEventListener('pointerdown', e => { e.preventDefault(); e.stopPropagation(); if (mapTap && mapTap.onCancel) mapTap.onCancel(); else endMapTap(); });
 
 // ---- AB flyout launchers → the three creation/management dialogs ----
 function abFlyoutClose() { bnAb.classList.remove('open'); document.getElementById('bn-abmenu').classList.remove('menuopen'); }
 document.getElementById('bn-tracks').addEventListener('pointerdown', e => { e.stopPropagation(); abFlyoutClose(); openTracksManager(); });
 document.getElementById('bn-quickab').addEventListener('pointerdown', e => { e.stopPropagation(); abFlyoutClose(); openDialog('dlg-quickab'); });
-document.getElementById('bn-drawab').addEventListener('pointerdown', e => { e.stopPropagation(); abFlyoutClose(); openDialog('dlg-drawab'); });
 // Quick-AB selector buttons.
+// Quick AB — the single creation hub: GPS-driven, from-boundary, and draw-on-map modes.
 document.getElementById('dlg-quickab').querySelectorAll('[data-qab]').forEach(b => b.addEventListener('pointerdown', e => {
   e.preventDefault(); e.stopPropagation(); closeDialog();
   const m = b.dataset.qab;
-  if (m === 'aPlus') transport.send('track.aPlus');
+  if (m === 'aPlus') {
+    // A+ builds an AB line from the vehicle's current position + heading. It needs a GPS
+    // fix; the host bails silently without one, so give feedback here (StatusMessage isn't
+    // on the wire). flashHint after a tick so it isn't cleared by the dialog close.
+    const p = tick && tick.pose;
+    if (!p || (!p.e && !p.n)) setTimeout(() => flashHint('A+ needs a GPS position — start the simulator or GPS'), 0);
+    else transport.send('track.aPlus');
+  }
   else if (m === 'driveAB') startDriveAB();
   else if (m === 'recordCurve') startRecordCurve();
+  else if (m === 'boundaryEdge') transport.send('track.createFromBoundary');
+  else if (m === 'boundaryCurve') startBoundaryCurve();
+  else if (m === 'allEdges') transport.send('track.allEdges');
+  else if (m === 'drawStraight') startDrawTrack('straight');
+  else if (m === 'drawCurve') startDrawTrack('curve');
 }));
 document.getElementById('dlg-qab-cancel').addEventListener('pointerdown', e => { e.preventDefault(); e.stopPropagation(); closeDialog(); });
-// Draw-AB selector buttons.
-document.getElementById('dlg-drawab').querySelectorAll('[data-draw]').forEach(b => b.addEventListener('pointerdown', e => {
-  e.preventDefault(); e.stopPropagation(); closeDialog();
-  const m = b.dataset.draw;
-  if (m === 'straight' || m === 'curve') startDrawTrack(m);
-  else if (m === 'boundaryEdge') transport.send('track.createFromBoundary');
-  else if (m === 'boundaryCurve') transport.send('track.boundaryCurve');
-  else if (m === 'allEdges') transport.send('track.allEdges');
-}));
-document.getElementById('dlg-drawab-cancel').addEventListener('pointerdown', e => { e.preventDefault(); e.stopPropagation(); closeDialog(); });
 
 // ---- Tracks manager (mirrors native TracksDialogPanel) ----
 // View-only without control (just reads scene.trackList); the actions are Tier-2.
@@ -3381,7 +3468,10 @@ function updateLightbarText() {
     const xte = tick.crossTrackError || 0;
     const onLine = Math.abs(xte) < 0.05;
     const arrow = onLine ? '●' : xte > 0 ? '◀' : '▶'; // arrow = steer direction
-    lbEl.textContent = `${arrow} ${(Math.abs(xte) * 100).toFixed(0)} cm   ${tick.lineLabel || ''}`;
+    // 1-based pass label (human counting): the reference AB line is "Pass 1", one over is
+    // "Pass 2", etc. — magnitude only (the arrow already shows which way to steer).
+    const pass = (tick.op ? tick.op.passNumber : 0) | 0;
+    lbEl.textContent = `${arrow} ${(Math.abs(xte) * 100).toFixed(0)} cm   Pass ${Math.abs(pass) + 1}`;
   }
   lbEl.style.display = 'block';
 }
@@ -4363,7 +4453,7 @@ function drawSatBoundarySk(canvas) {
 // blue B (last), white interior — so the placed A point is visible before B is set. The
 // host holds the real point list; drawPts is the client's tap echo (preview only).
 function drawAbDrawPreviewSk(canvas) {
-  if (!drawMode || !drawPts.length) return;
+  if (!drawPts.length) return; // renders for map-tap AND Drive-AB markers (drawMode may be null)
   const rad = Math.max(5, 0.6 * pxPerM);
   for (let i = 0; i < drawPts.length; i++) {
     const p = drawPts[i];
@@ -4981,19 +5071,23 @@ function renderSkia(canvas, rp) {
     drawExtraGuidelinesSk(canvas); // faint adjacent passes (under the bold lines)
     if (scene.nextTrack) strokePtsSk(canvas, scene.nextTrack, false, SKP.next);
     if (scene.uTurnPath) strokePtsSk(canvas, scene.uTurnPath, false, SKP.uturn);
-    if (scene.guidanceLine) strokePtsSk(canvas, scene.guidanceLine, false, SKP.guidance);
-    // Reference AB (the selected track, fixed at where it was drawn) — purple dashed,
-    // drawn AFTER the magenta DisplayLine so the dashes show on top. scene.tracks is
-    // active-only, so this is just the active reference; the offset magenta sits a pass
-    // away from it once the tractor moves over.
-    for (const tr of scene.tracks)
+    // Purple reference (extended across the field) — drawn ONLY when the tractor is offset from
+    // it (pass ≠ 0). On the reference pass it coincides with the magenta guidance, so we show
+    // just the one line. Matches the host's baseTrack = nearestPass!=0?track:null intent.
+    const _onRef = !tick || !tick.op || (tick.op.passNumber | 0) === 0;
+    if (!_onRef) for (const tr of scene.tracks)
       strokePtsSk(canvas, extendAbLine(tr.points), false, SKP.reference);
+    // Magenta current pass, extended across the field. The host's DisplayLine is only ~track
+    // length (a 2-point offset AB); extendAbLine spans it full-field, so an offset pass isn't a
+    // short stub. Curves are >2 points and already host-extended, so they pass through unchanged.
+    if (scene.guidanceLine) strokePtsSk(canvas, extendAbLine(scene.guidanceLine), false, SKP.guidance);
     drawFlagsSk(canvas, scene.flags);
   }
   drawRecordingMarkersSk(canvas); // live recorded-path dots (independent of the Scene)
   drawBoundaryRecordingSk(canvas); // live drive-around boundary line + dots
   drawSatBoundarySk(canvas); // live boundary-on-satellite polygon being drawn
   drawAbDrawPreviewSk(canvas); // #40 — A/B (orange/blue) dots for the AB/curve being drawn
+  drawCurveMarksSk(canvas); // record-curve path dots (Set Point A → B)
   drawDrawingSk(canvas); // live draw-on-map AB/curve preview (Phase MT)
   drawHeadlandDrawSk(canvas); // live headland draw preview (Field Builder stage 2)
   drawHeadlandSegEditLinesSk(canvas); // headland-editor offset lines (yellow/red) while editing
@@ -5015,6 +5109,7 @@ function skFrame() {
   else { _fpsFrames++; const dt = _now - _fpsT0; if (dt >= 500) { fps = _fpsFrames * 1000 / dt; _fpsFrames = 0; _fpsT0 = _now; } }
   const rp = updateCamera(); // follow mode + rotation + perspM, once per frame
   maybeSaveView();           // persist tilt/zoom changes (debounced) — issue #35
+  sampleCurveMark();         // drop record-curve path dots as the vehicle drives
   if (skSurface) {
     try { renderSkia(skSurface.getCanvas(), rp); skSurface.flush(); }
     catch (e) { ckStatus = 'render err: ' + (e && e.message || e); }

--- a/Shared/AgOpenWeb.RemoteServer/wwwroot/app.js
+++ b/Shared/AgOpenWeb.RemoteServer/wwwroot/app.js
@@ -3483,7 +3483,11 @@ const hlHud = document.getElementById('headland-hud');
 function updateHeadlandHud() {
   const on = config && config.display && config.display.headlandDistanceVisible;
   const d = tick ? tick.headlandDist : -1;
-  if (!on || d == null || d < 0) { hlHud.style.display = 'none'; return; }
+  // Hide the HUD while a map-tap creation flow is active (Quick AB / boundary curve / draw / …):
+  // the boundary distance isn't needed while placing points, and it would clutter the top-centre
+  // instruction pill + toolbar. body.maptap is set by startMapTap for the duration of the flow.
+  const creating = document.body.classList.contains('maptap');
+  if (!on || creating || d == null || d < 0) { hlHud.style.display = 'none'; return; }
   const metric = !statusBar || statusBar.isMetric;
   hlHud.textContent = metric ? d.toFixed(1) + ' m' : (d * 3.28084).toFixed(0) + ' ft';
   hlHud.classList.toggle('warn', !!(tick && tick.headlandWarn));

--- a/Shared/AgOpenWeb.RemoteServer/wwwroot/index.html
+++ b/Shared/AgOpenWeb.RemoteServer/wwwroot/index.html
@@ -160,7 +160,16 @@
       pointer-events: none; z-index: 40; box-shadow: 0 2px 10px rgba(0,0,0,0.4);
     }
     #maptap-hint.show { display: block; }
-    #maptap-hint::after { content: '  ·  Esc to cancel'; opacity: 0.6; font-weight: 400; }
+    /* "Esc to cancel" only on pointer devices with a keyboard; touch cancels via the red
+       Cancel button in the draw toolbar (no Esc key on a tablet). */
+    @media (pointer: fine) { #maptap-hint::after { content: '  ·  Esc to cancel'; opacity: 0.6; font-weight: 400; } }
+    /* Touch cancel for bare map-tap flows (flag placement) that have no draw toolbar. Shown
+       by startMapTap only when the toolbar isn't up, so it never doubles the toolbar Cancel. */
+    #maptap-cancel { position: fixed; top: calc(102px + var(--sat)); left: 50%; transform: translateX(-50%);
+      display: none; z-index: 41; padding: 8px 22px; border-radius: 999px; cursor: pointer;
+      border: 1px solid rgba(230,120,110,0.7); background: rgba(52,22,20,0.94); color: #f3c4bd;
+      font: 700 14px system-ui, sans-serif; box-shadow: 0 2px 10px rgba(0,0,0,0.4); }
+    #maptap-cancel.show { display: block; }
     body.maptap #ck { cursor: crosshair; }
     /* A/B letter that rides the crosshair while drawing a straight AB line (#40): shows
        which point the next tap places. Colour matches the placed dots (A orange, B blue). */
@@ -168,6 +177,9 @@
       font: 900 24px system-ui, sans-serif; transform: translate(15px, -30px);
       text-shadow: 0 0 3px #000, 0 1px 5px rgba(0,0,0,0.95); }
     #maptap-ab.show { display: block; }
+    /* The crosshair letter is mouse-only (no hover to ride on touch); the dot letters +
+       banner cover touch. Belt-and-suspenders with the pointerType gate in JS. */
+    @media (pointer: coarse) { #maptap-ab { display: none !important; } }
     /* Persistent letter next to each dropped AB/curve point (#40). Positioned per-frame. */
     #ab-dot-labels span { position: fixed; z-index: 41; display: none; pointer-events: none;
       font: 900 20px system-ui, sans-serif; transform: translate(11px, -26px);
@@ -1100,6 +1112,7 @@
   <div id="lb"></div>
   <div id="headland-hud"></div>
   <div id="maptap-hint"></div>
+  <button id="maptap-cancel">✕ Cancel</button>
   <div id="maptap-ab">A</div>
   <div id="ab-dot-labels"></div>
   <!-- Phase MT — draw-track toolbar. Shown while drawing an AB/curve on the map.
@@ -2458,17 +2471,13 @@
       </div>
       <div id="bn-flyout-ab" class="bn-flyout">
         <!-- Mirrors native BottomNavigationPanel AB flyout. Row 1: Tracks manager /
-             Auto-track / Quick-AB selector. Row 2: boundary-edge AB / Draw-on-map
-             selector. Then the active-track ops (cycle/smooth/delete + nudges), shown
-             only with an active track (.bn-abdep). Tracks/QuickAB/DrawAB open dialogs. -->
+             Auto-track / Quick-AB (the single creation hub — GPS-driven, from-boundary,
+             and draw-on-map all live in its dialog). Then the active-track ops
+             (cycle/smooth/delete + nudges), shown only with an active track (.bn-abdep). -->
         <div class="bn-flyrow">
           <button class="bn-btn" id="bn-tracks" title="Tracks — manage AB lines"><img class="bn-ic" src="/icons/ABTracks.png" alt="Tracks"></button>
           <button class="bn-btn" id="bn-autotrack" data-cmd="track.autoTrack" data-t2 title="Auto track select (closest track)">AT</button>
           <button class="bn-btn" id="bn-quickab" title="Quick AB line creator"><img class="bn-ic" src="/icons/ABTrackAPlus.png" alt="Quick AB"></button>
-        </div>
-        <div class="bn-flyrow">
-          <button class="bn-btn" data-cmd="track.createFromBoundary" title="Create AB line from boundary edge">BE</button>
-          <button class="bn-btn" id="bn-drawab" title="Draw AB line on map"><img class="bn-ic" src="/icons/ABDraw.png" alt="Draw AB"></button>
         </div>
         <div class="bn-flysep bn-abdep"></div>
         <div class="bn-flyrow bn-abdep">
@@ -2544,32 +2553,28 @@
         <button id="ucov-save" class="dlg-btn dlg-ok">Save to Job</button>
       </div>
     </div>
-    <!-- Quick AB Line creator (mirrors native QuickABSelectorPanel) — GPS-driven modes. -->
+    <!-- Quick AB Line — the single AB/track creation hub. Three sections: GPS-driven,
+         from-boundary, and draw-on-map (all methods live here; no separate Draw dialog). -->
     <div id="dlg-quickab" class="dlg-card">
       <div class="dlg-title">Quick AB Line</div>
-      <div class="dlg-msg">Select a creation mode</div>
+      <div class="dlg-sub">By Driving</div>
       <div class="dlg-modes">
         <button class="dlg-mode" data-qab="aPlus" title="AB line from current position &amp; heading"><img src="/icons/ABTrackAPlus.png" alt=""><span>A+</span></button>
         <button class="dlg-mode" data-qab="driveAB" title="Drive from A to B"><img src="/icons/ABTrackAB.png" alt=""><span>Drive AB</span></button>
         <button class="dlg-mode" data-qab="recordCurve" title="Drive to record a curve"><img src="/icons/ABTrackCurve.png" alt=""><span>Curve</span></button>
       </div>
-      <div class="dlg-buttons"><button id="dlg-qab-cancel" class="dlg-btn dlg-cancel">Cancel</button></div>
-    </div>
-    <!-- Draw AB on map (mirrors native DrawABDialogPanel) — map-tap + boundary creation. -->
-    <div id="dlg-drawab" class="dlg-card">
-      <div class="dlg-title">Draw Track on Map</div>
-      <div class="dlg-msg">Tap on the map to place points</div>
-      <div class="dlg-modes">
-        <button class="dlg-mode" data-draw="straight" title="Tap 2 points for a straight AB line"><img src="/icons/ABTrackAB.png" alt=""><span>Straight</span></button>
-        <button class="dlg-mode" data-draw="curve" title="Tap points for a curve, then Finish"><img src="/icons/ABTrackCurve.png" alt=""><span>Curve</span></button>
-      </div>
       <div class="dlg-sub">From Field Boundary</div>
       <div class="dlg-modes">
-        <button class="dlg-mode" data-draw="boundaryEdge" title="AB line along the longest boundary edge"><span class="dlg-bigtxt">AB</span><span>Longest Edge</span></button>
-        <button class="dlg-mode" data-draw="boundaryCurve" title="Curve following the whole boundary"><img src="/icons/ABTrackCurve.png" alt=""><span>Bnd. Curve</span></button>
-        <button class="dlg-mode" data-draw="allEdges" title="AB line for every boundary edge"><span class="dlg-bigtxt">All</span><span>All Edges</span></button>
+        <button class="dlg-mode" data-qab="boundaryEdge" title="AB line along the longest boundary edge"><span class="dlg-bigtxt">AB</span><span>Longest Edge</span></button>
+        <button class="dlg-mode" data-qab="boundaryCurve" title="Curve following the whole boundary"><img src="/icons/ABTrackCurve.png" alt=""><span>Bnd. Curve</span></button>
+        <button class="dlg-mode" data-qab="allEdges" title="AB line for every boundary edge"><span class="dlg-bigtxt">All</span><span>All Edges</span></button>
       </div>
-      <div class="dlg-buttons"><button id="dlg-drawab-cancel" class="dlg-btn dlg-cancel">Cancel</button></div>
+      <div class="dlg-sub">Draw on Map</div>
+      <div class="dlg-modes">
+        <button class="dlg-mode" data-qab="drawStraight" title="Tap 2 points on the map for a straight AB line"><img src="/icons/ABTrackAB.png" alt=""><span>Straight</span></button>
+        <button class="dlg-mode" data-qab="drawCurve" title="Tap points on the map for a curve, then Finish"><img src="/icons/ABTrackCurve.png" alt=""><span>Curve</span></button>
+      </div>
+      <div class="dlg-buttons"><button id="dlg-qab-cancel" class="dlg-btn dlg-cancel">Cancel</button></div>
     </div>
     <!-- Tracks manager (mirrors native TracksDialogPanel) — list + toolbar. -->
     <div id="dlg-tracks" class="dlg-card dlg-wide">

--- a/Shared/AgOpenWeb.RemoteServer/wwwroot/index.html
+++ b/Shared/AgOpenWeb.RemoteServer/wwwroot/index.html
@@ -143,7 +143,9 @@
     }
     /* Headland-distance HUD — screen-space box at top-centre (below the light bar),
        mirroring the native SkiaMapControl HUD. Green when clear, red on warning.
-       Gated by Display.HeadlandDistanceVisible + a live distance ≥ 0. */
+       Gated by Display.HeadlandDistanceVisible + a live distance ≥ 0, AND hidden while a
+       map-tap creation flow is active (updateHeadlandHud) so it doesn't clutter the top-centre
+       instruction pill / draw toolbar. */
     #headland-hud {
       position: fixed; top: calc(102px + var(--sat)); left: 50%; transform: translateX(-50%); display: none;
       padding: 6px 18px; border-radius: 8px; border: 1px solid rgba(var(--ov),0.25);
@@ -186,7 +188,7 @@
       text-shadow: 0 0 3px #000, 0 1px 5px rgba(0,0,0,0.95); }
     /* Draw-track toolbar (Phase MT) — top-centre, directly under the instruction pill
        (#maptap-hint at top:60px) so the action buttons sit with the prompt, not across
-       the screen from it. */
+       the screen from it. (The distance HUD is hidden during these flows — updateHeadlandHud.) */
     #draw-toolbar {
       position: fixed; top: calc(100px + var(--sat)); left: 50%; transform: translateX(-50%); display: none;
       gap: 10px; z-index: 41;
@@ -2476,8 +2478,8 @@
              (cycle/smooth/delete + nudges), shown only with an active track (.bn-abdep). -->
         <div class="bn-flyrow">
           <button class="bn-btn" id="bn-tracks" title="Tracks — manage AB lines"><img class="bn-ic" src="/icons/ABTracks.png" alt="Tracks"></button>
-          <button class="bn-btn" id="bn-autotrack" data-cmd="track.autoTrack" data-t2 title="Auto track select (closest track)">AT</button>
           <button class="bn-btn" id="bn-quickab" title="Quick AB line creator"><img class="bn-ic" src="/icons/ABTrackAPlus.png" alt="Quick AB"></button>
+          <button class="bn-btn" id="bn-autotrack" data-cmd="track.autoTrack" data-t2 title="Auto track select (closest track)">AT</button>
         </div>
         <div class="bn-flysep bn-abdep"></div>
         <div class="bn-flyrow bn-abdep">

--- a/Shared/AgOpenWeb.RemoteServer/wwwroot/transport.js
+++ b/Shared/AgOpenWeb.RemoteServer/wwwroot/transport.js
@@ -107,6 +107,7 @@ window.RemoteTransport = {
           const vehicleSteerAngle = f32();
           const hostMs = f64(); // host monotonic build time — the interp timeline
           op.executing = !!u8(); // #50 — u-turn arc executing (blocks on-screen U-turn/Lateral)
+          op.passNumber = i32(); // guidance pass offset (0 = on reference) — reference gate + label
           handlers.onTick && handlers.onTick({
             sceneVersion, pose, fix, sections, crossTrackError, guidanceActive, lineLabel,
             activeTrackName: atn.length ? atn : null, tool, op, roll, tools,

--- a/Shared/AgOpenWeb.RemoteWiring/RemoteServerWiring.Helpers.cs
+++ b/Shared/AgOpenWeb.RemoteWiring/RemoteServerWiring.Helpers.cs
@@ -15,7 +15,7 @@ public static partial class RemoteServerWiring
         "track.drawStraight", "track.drawCurve", "track.drawPoint", "track.drawFinish",
         "track.drawUndo", "track.drawCancel", "track.aPlus", "track.driveAB",
         "track.recordCurve", "track.finishCurve", "track.setABGps",
-        "track.createFromBoundary", "track.boundaryCurve", "track.allEdges",
+        "track.createFromBoundary", "track.boundaryCurve", "track.boundaryCurveSeg", "track.allEdges",
         "track.setVisible", "track.toggleRecPaths", "track.editSave",
     };
 

--- a/Shared/AgOpenWeb.RemoteWiring/RemoteServerWiring.cs
+++ b/Shared/AgOpenWeb.RemoteWiring/RemoteServerWiring.cs
@@ -309,6 +309,17 @@ public static partial class RemoteServerWiring
                                     }
                                     return;
                                 }
+                                case "track.boundaryCurveSeg": // "Bnd. Curve": tap A + B on the boundary.
+                                {                              // arg = "aE,aN,bE,bN" (m, from s2w). Tier-1.
+                                    var bc = arg.Split(',');
+                                    if (bc.Length >= 4
+                                        && double.TryParse(bc[0], num, inv, out var caE)
+                                        && double.TryParse(bc[1], num, inv, out var caN)
+                                        && double.TryParse(bc[2], num, inv, out var cbE)
+                                        && double.TryParse(bc[3], num, inv, out var cbN))
+                                        vm.RemoteCreateBoundaryCurveSegment(caE, caN, cbE, cbN);
+                                    return;
+                                }
                                 case "flag.placeAt": // Phase MT map-tap. arg = "easting,northing"
                                 {                     // (m, field-local, from s2w). Tier-1 marker.
                                     var fp = arg.Split(',');

--- a/Shared/AgOpenWeb.Services/GeoJson/GeoJsonFieldService.cs
+++ b/Shared/AgOpenWeb.Services/GeoJson/GeoJsonFieldService.cs
@@ -254,6 +254,7 @@ public class GeoJsonFieldService
                 [FieldPropertyKeys.Name] = track.Name,
                 [FieldPropertyKeys.TrackType] = (int)track.Type,
                 [FieldPropertyKeys.IsClosed] = track.IsClosed,
+                [FieldPropertyKeys.NoPassOffset] = track.NoPassOffset,
                 [FieldPropertyKeys.NudgeDistance] = track.NudgeDistance,
                 [FieldPropertyKeys.IsVisible] = track.IsVisible,
             }
@@ -362,6 +363,7 @@ public class GeoJsonFieldService
             Points = points,
             Type = trackType,
             IsClosed = GetBoolProp(feature, FieldPropertyKeys.IsClosed),
+            NoPassOffset = GetBoolProp(feature, FieldPropertyKeys.NoPassOffset),
             NudgeDistance = GetDoubleProp(feature, FieldPropertyKeys.NudgeDistance),
             IsVisible = GetBoolPropDefault(feature, FieldPropertyKeys.IsVisible, true),
         };

--- a/Shared/AgOpenWeb.Services/Pipeline/GpsPipelineService.cs
+++ b/Shared/AgOpenWeb.Services/Pipeline/GpsPipelineService.cs
@@ -519,6 +519,12 @@ public sealed class GpsPipelineService : IGpsPipelineService
             _nextUTurnDirectionLeftOverride = null;
         }
 
+        // Boundary-follow curve (NoPassOffset): only SUPPRESS the free-drive nearest-pass snap
+        // (below) so it stays where you put it — it starts on the boundary (pass 0, seeded from
+        // NudgeDistance) instead of jumping to the pass nearest a parked tractor. Laterals,
+        // nudges and U-turns still change the pass normally; we don't pin it here.
+        bool noPassOffset = track != null && track.NoPassOffset;
+
         // No-headland workflow: substitute a synthetic headland line that
         // sits one (turn radius + UTurnDistanceFromBoundary) inset from the
         // outer boundary, so the auto-uturn arc's apex lands inside the
@@ -922,7 +928,7 @@ public sealed class GpsPipelineService : IGpsPipelineService
                 _autoSteerService.UpdateGuidanceResults(steerAngle, crossTrackError);
             }
         }
-        if (!autoSteerEngaged && hasTrack)
+        if (!autoSteerEngaged && hasTrack && !noPassOffset)
         {
             // Display-only: auto-detect nearest pass and update visualization.
             // Phase D D3: write the detected pass directly into the cycle's

--- a/Shared/AgOpenWeb.Services/Pipeline/GpsPipelineService.cs
+++ b/Shared/AgOpenWeb.Services/Pipeline/GpsPipelineService.cs
@@ -525,12 +525,15 @@ public sealed class GpsPipelineService : IGpsPipelineService
         // nudges and U-turns still change the pass normally; we don't pin it here.
         bool noPassOffset = track != null && track.NoPassOffset;
 
-        // No-headland workflow: substitute a synthetic headland line that
-        // sits one (turn radius + UTurnDistanceFromBoundary) inset from the
-        // outer boundary, so the auto-uturn arc's apex lands inside the
-        // outer boundary. headlandCalculatedWidth is set to the inset so
-        // downstream U-turn geometry (HeadlandWidth, leg lengths) is
-        // consistent with the synthesized line.
+        // No-headland workflow: substitute the outer-boundary TURN LINE for the
+        // missing headland line — the AgOpen model (CTurn.BuildTurnLines): the
+        // fence offset inward by just UTurnDistanceFromBoundary. This line is the
+        // "in-turn-bounds" polygon the state machine gates arming on and raycasts
+        // distance to; a fence-hugging boundary-follow pass (offset ~half a tool
+        // inside the fence) sits INSIDE it, so it arms via the normal cultivated-
+        // zone path. The turn's actual geometry is anchored on the turn boundary
+        // built inside BuildCreationInput (also offset by UTurnDistanceFromBoundary)
+        // and fitted by MoveTurnInsideTurnLine, so this line does not shape the arc.
         if (headlandLine == null && boundary?.OuterBoundary != null && boundary.OuterBoundary.IsValid)
         {
             var synth = GetOrComputeSyntheticHeadland(boundary);
@@ -1594,13 +1597,13 @@ public sealed class GpsPipelineService : IGpsPipelineService
     private (List<Vec3>? Line, double Inset) GetOrComputeSyntheticHeadland(Boundary boundary)
     {
         var guidanceConfig = _configStore.Guidance;
-        double turnRadius = guidanceConfig.UTurnRadius;
-        double distFromBoundary = guidanceConfig.UTurnDistanceFromBoundary;
-        double inset = turnRadius + distFromBoundary;
-        // Pack the two doubles into a single key. UTurnRadius is small (<20m)
-        // so multiplying by 1000 and adding distance keeps both contributions
-        // distinguishable for cache invalidation purposes.
-        double configKey = turnRadius * 1000.0 + distFromBoundary;
+        // AgOpen CTurn.BuildTurnLines: turn line = fence inset by uturnDistanceFromBoundary
+        // ONLY (no turn-radius inset). A deeper inset would push a fence-hugging boundary
+        // pass outside the "in-turn-bounds" polygon and it would never arm; the turn radius
+        // is accounted for by MoveTurnInsideTurnLine fitting the arc, not by pre-insetting
+        // this line.
+        double inset = guidanceConfig.UTurnDistanceFromBoundary;
+        double configKey = inset;
 
         if (ReferenceEquals(boundary, _syntheticHeadlandSourceBoundary)
             && Math.Abs(configKey - _syntheticHeadlandConfigKey) < 1e-9)
@@ -1618,8 +1621,8 @@ public sealed class GpsPipelineService : IGpsPipelineService
         _syntheticHeadlandSourceBoundary = boundary;
         _syntheticHeadlandConfigKey = configKey;
         _syntheticHeadlandInsetUsed = inset;
-        _logger.LogDebug("[YouTurn] Synthesized headland (no user headland): inset={I:F1}m (turnR={R:F1}+dist={D:F1}), pts={P}",
-            inset, turnRadius, distFromBoundary, _syntheticHeadlandLine?.Count ?? 0);
+        _logger.LogDebug("[YouTurn] Synthesized turn line (no user headland): inset={I:F1}m (uturnDistanceFromBoundary), pts={P}",
+            inset, _syntheticHeadlandLine?.Count ?? 0);
         return (_syntheticHeadlandLine, _syntheticHeadlandInsetUsed);
     }
 

--- a/Shared/AgOpenWeb.Services/YouTurn/YouTurnPathingService.cs
+++ b/Shared/AgOpenWeb.Services/YouTurn/YouTurnPathingService.cs
@@ -194,6 +194,19 @@ public sealed class YouTurnPathingService
         double widthMinusOverlap = config.ActualToolWidth - config.Tool.Overlap;
         double nextDistAway = widthMinusOverlap * nextPathsAway;
 
+        // Curves: sample the ACTUAL offset curve, not the straight A→B chord. An irregular
+        // boundary curve's chord can sit well off the real line, so the chord test picks the
+        // wrong side (the outward one, outside the fence — the "return path outside boundary"
+        // bug). Offsetting the real curve points is accurate for either direction.
+        if (currentTrack.Points.Count > 2)
+        {
+            var offsetCurve = CurveProcessing.CreateOffsetCurve(currentTrack.Points, nextDistAway);
+            foreach (var p in offsetCurve)
+                if (IsPointInsideCultivatedArea(p.Easting, p.Northing, boundary, headlandLine))
+                    return true;
+            return false;
+        }
+
         var pointA = currentTrack.Points[0];
         var pointB = currentTrack.Points[currentTrack.Points.Count - 1];
         double perpAngle = abHeading + Math.PI / 2;

--- a/Shared/AgOpenWeb.Services/YouTurn/YouTurnStateMachine.cs
+++ b/Shared/AgOpenWeb.Services/YouTurn/YouTurnStateMachine.cs
@@ -230,12 +230,18 @@ public sealed class YouTurnStateMachine
                 (currentPosition.Easting - turnStart.Easting) * (currentPosition.Easting - turnStart.Easting) +
                 (currentPosition.Northing - turnStart.Northing) * (currentPosition.Northing - turnStart.Northing));
 
-            // Publish current pivot→trigger distance for the UI countdown widget.
-            // Only meaningful while a precomputed turn-start exists and we haven't
-            // begun executing yet; once IsExecuting flips, the widget is expected
-            // to switch to a "turning" state and we revert to 0 (set above).
-            turn.DistanceToTrigger = distToTurnStart;
+            // Publish the pivot→trigger distance for the UI countdown widget as ARC LENGTH
+            // ALONG THE TRACK, not straight-line. On a curve that wraps a field end, the turn
+            // start can be far to the east while the tractor drives west around the wrap toward
+            // it — a Euclidean distance would COUNT UP as it drives away in a straight line, when
+            // the operator expects it to COUNT DOWN as the pass is worked. Falls back to the
+            // straight-line value for AB lines (2-point tracks) where the two are identical.
+            turn.DistanceToTrigger = track.Points.Count > 2
+                ? ArcLengthAlongTrack(track.Points, currentPosition, turnStart)
+                : distToTurnStart;
 
+            // Trigger on physical proximity (straight-line): the tractor must actually reach the
+            // turn start, regardless of how the arc-length display reads.
             if (distToTurnStart <= TriggerProximityMeters)
             {
                 turn.IsTriggered = true;
@@ -379,6 +385,43 @@ public sealed class YouTurnStateMachine
             remaining += Math.Sqrt(dx * dx + dy * dy);
         }
         return remaining;
+    }
+
+    /// <summary>
+    /// Arc length along <paramref name="track"/> between the point nearest
+    /// <paramref name="pivot"/> and the point nearest <paramref name="turnStart"/>. Gives a
+    /// "distance remaining as the pass is worked" that decreases as the tractor advances toward
+    /// the turn, even when the turn start is straight-line far away (a curve wrapping a field
+    /// end). Snaps both ends to the nearest track point, so the readout steps at roughly the
+    /// track point spacing (~2 m) — fine for a distance display.
+    /// </summary>
+    private static double ArcLengthAlongTrack(
+        IReadOnlyList<Vec3> track, Position pivot, Vec3 turnStart)
+    {
+        int NearestIdx(double e, double n)
+        {
+            int best = 0; double bestSq = double.MaxValue;
+            for (int i = 0; i < track.Count; i++)
+            {
+                double de = track[i].Easting - e, dn = track[i].Northing - n;
+                double d2 = de * de + dn * dn;
+                if (d2 < bestSq) { bestSq = d2; best = i; }
+            }
+            return best;
+        }
+
+        int pivotIdx = NearestIdx(pivot.Easting, pivot.Northing);
+        int turnIdx = NearestIdx(turnStart.Easting, turnStart.Northing);
+        int lo = Math.Min(pivotIdx, turnIdx), hi = Math.Max(pivotIdx, turnIdx);
+
+        double len = 0;
+        for (int i = lo; i < hi; i++)
+        {
+            double de = track[i + 1].Easting - track[i].Easting;
+            double dn = track[i + 1].Northing - track[i].Northing;
+            len += Math.Sqrt(de * de + dn * dn);
+        }
+        return len;
     }
 
     /// <summary>

--- a/Shared/AgOpenWeb.ViewModels/MainViewModel.Commands.Track.cs
+++ b/Shared/AgOpenWeb.ViewModels/MainViewModel.Commands.Track.cs
@@ -68,6 +68,78 @@ public partial class MainViewModel
         StatusMessage = "Applied area deleted";
     }
 
+    /// <summary>
+    /// Boundary curve from two tapped points (remote/web "Bnd. Curve"): snap A and B to the
+    /// nearest outer-boundary vertices, walk the shorter arc between them, and create an OPEN
+    /// curve following the boundary. Mirrors native FormABDraw's BtnMakeCurve segment logic.
+    /// </summary>
+    public void RemoteCreateBoundaryCurveSegment(double aE, double aN, double bE, double bN)
+    {
+        var boundary = State.Field.CurrentBoundary?.OuterBoundary;
+        if (boundary?.Points == null || boundary.Points.Count < 3)
+        {
+            StatusMessage = "Load a field with a boundary first";
+            return;
+        }
+        // Offset the boundary inward by half the tool width so the curve sits half-an-implement
+        // inside the fence (following it keeps the whole implement in the field — #422, same as
+        // the whole-boundary curve). Fall back to the raw boundary if the offset fails.
+        double halfTool = ConfigStore.ActualToolWidth / 2.0;
+        var rawVec2 = new System.Collections.Generic.List<Models.Base.Vec2>(boundary.Points.Count);
+        foreach (var p in boundary.Points) rawVec2.Add(new Models.Base.Vec2(p.Easting, p.Northing));
+        var offset = halfTool > 0.05 ? _polygonOffsetService.CreateInwardOffset(rawVec2, halfTool) : null;
+        var ring = (offset != null && offset.Count >= 3) ? offset : rawVec2;
+        int n = ring.Count;
+
+        int NearestIndex(double e, double north)
+        {
+            int best = 0; double bd = double.MaxValue;
+            for (int i = 0; i < n; i++)
+            {
+                double dx = ring[i].Easting - e, dy = ring[i].Northing - north;
+                double d = dx * dx + dy * dy;
+                if (d < bd) { bd = d; best = i; }
+            }
+            return best;
+        }
+
+        int ai = NearestIndex(aE, aN);
+        int bi = NearestIndex(bE, bN);
+        if (ai == bi) { StatusMessage = "Pick two different points on the boundary"; return; }
+
+        // Walk the SHORTER arc A→B around the closed ring (mirrors FormABDraw's wrap check).
+        int forward = (bi - ai + n) % n;
+        int step = forward <= n - forward ? 1 : -1;
+        var seg = new System.Collections.Generic.List<Models.Base.Vec3>();
+        for (int i = ai; ; i = (i + step + n) % n)
+        {
+            seg.Add(new Models.Base.Vec3(ring[i].Easting, ring[i].Northing, 0));
+            if (i == bi) break;
+        }
+
+        if (seg.Count < 3) { StatusMessage = "Segment too short for a curve"; return; }
+
+        // Round the boundary's sharp corners so the tractor can actually drive it (Chaikin
+        // corner-cutting), then heading per point (guidance's forward test keys off it).
+        var smoothed = Models.Guidance.CurveProcessing.ChaikinsSmooth(seg, 3);
+        var curvePoints = Models.Guidance.CurveProcessing.CalculateHeadings(smoothed);
+        var track = new Models.Track.Track
+        {
+            Name = "Boundary Curve",
+            Points = curvePoints,
+            Type = Models.Track.TrackType.Curve,
+            IsVisible = true,
+            IsClosed = false,
+            // Drive the boundary itself: this curve isn't worked in parallel passes, so the
+            // guidance follows it directly (pass 0) instead of free-drive snapping to an inner pass.
+            NoPassOffset = true
+        };
+        SavedTracks.Add(track);
+        SelectedTrack = track;
+        SaveTracksToFile();
+        StatusMessage = $"Created boundary curve ({curvePoints.Count} points, {halfTool:F1} m inside fence)";
+    }
+
     private void InitializeTrackCommands()
     {
         // AB Line Guidance Commands - Bottom Bar

--- a/Shared/AgOpenWeb.ViewModels/MainViewModel.Commands.Track.cs
+++ b/Shared/AgOpenWeb.ViewModels/MainViewModel.Commands.Track.cs
@@ -81,13 +81,16 @@ public partial class MainViewModel
             StatusMessage = "Load a field with a boundary first";
             return;
         }
-        // Offset the boundary inward by half the tool width so the curve sits half-an-implement
-        // inside the fence (following it keeps the whole implement in the field — #422, same as
-        // the whole-boundary curve). Fall back to the raw boundary if the offset fails.
-        double halfTool = ConfigStore.ActualToolWidth / 2.0;
+        // Offset the boundary inward by half the tool width PLUS half the U-turn clearance so the
+        // curve sits a half-implement inside the fence AND clears the turn line (which is
+        // UTurnDistanceFromBoundary inside) with margin — following it keeps the whole implement in
+        // the field (#422) while the pass stays inside the cultivated/turn zone. Fall back to the
+        // raw boundary if the offset fails.
+        double insetDistance = ConfigStore.ActualToolWidth / 2.0
+            + ConfigStore.Guidance.UTurnDistanceFromBoundary / 2.0;
         var rawVec2 = new System.Collections.Generic.List<Models.Base.Vec2>(boundary.Points.Count);
         foreach (var p in boundary.Points) rawVec2.Add(new Models.Base.Vec2(p.Easting, p.Northing));
-        var offset = halfTool > 0.05 ? _polygonOffsetService.CreateInwardOffset(rawVec2, halfTool) : null;
+        var offset = insetDistance > 0.05 ? _polygonOffsetService.CreateInwardOffset(rawVec2, insetDistance) : null;
         var ring = (offset != null && offset.Count >= 3) ? offset : rawVec2;
         int n = ring.Count;
 
@@ -122,7 +125,12 @@ public partial class MainViewModel
         // Round the boundary's sharp corners so the tractor can actually drive it (Chaikin
         // corner-cutting), then heading per point (guidance's forward test keys off it).
         var smoothed = Models.Guidance.CurveProcessing.ChaikinsSmooth(seg, 3);
-        var curvePoints = Models.Guidance.CurveProcessing.CalculateHeadings(smoothed);
+        var headed = Models.Guidance.CurveProcessing.CalculateHeadings(smoothed);
+        // Extend both ends past the field boundary along their tangents — exactly like the
+        // hand-drawn curve tool (ExtendCurvePastBoundary) and an AB line. Without this the curve
+        // stops inside the field and the U-turn generator has no boundary crossing to anchor the
+        // turn at each pass end; with it, the ends run past the fence and turns fire normally.
+        var curvePoints = ExtendCurvePastBoundary(headed);
         var track = new Models.Track.Track
         {
             Name = "Boundary Curve",
@@ -137,7 +145,7 @@ public partial class MainViewModel
         SavedTracks.Add(track);
         SelectedTrack = track;
         SaveTracksToFile();
-        StatusMessage = $"Created boundary curve ({curvePoints.Count} points, {halfTool:F1} m inside fence)";
+        StatusMessage = $"Created boundary curve ({curvePoints.Count} points, {insetDistance:F1} m inside fence)";
     }
 
     private void InitializeTrackCommands()
@@ -1624,14 +1632,42 @@ public partial class MainViewModel
             lastPoint.Northing + cosEnd2 * extendEnd,
             endHeading);
 
-        // Insert extended start at beginning, replace first point
-        result[0] = extendedStart;
-        // Append extended end, replace last point
-        result[^1] = extendedEnd;
+        // DENSIFY the extensions instead of replacing the endpoints with a single far point.
+        // A boundary curve's end can extend a very long way (e.g. its tangent runs along the
+        // fence, so the raycast lands on the OPPOSITE fence hundreds of metres away). Left as a
+        // lone 2-point segment, a tractor sitting on that long segment finds the far endpoint
+        // (index 0) as its nearest curve point — and FindCurveTurnPoint's walk (`j > 0`) can't
+        // advance from index 0, so it finds no crossing, the U-turn generator fails, and the
+        // straight-line fallback mis-plots the turn at whatever fence the travel-heading raycast
+        // hits (the "U-turn in the wrong corner" bug). Densified points keep the nearest index in
+        // the interior so the walk proceeds in either direction.
+        const double extSpacing = 2.0;
+        var densified = new List<Vec3>(result.Count + 64);
 
-        _logger.LogDebug($"[Curve] Extended start by {extendStart:F1}m, end by {extendEnd:F1}m");
+        int leadSteps = Math.Max(1, (int)(extendStart / extSpacing));
+        for (int i = 0; i < leadSteps; i++)
+        {
+            double f = (double)i / leadSteps; // 0 at extended tip → 1 at firstPoint (exclusive)
+            densified.Add(new Vec3(
+                extendedStart.Easting + (firstPoint.Easting - extendedStart.Easting) * f,
+                extendedStart.Northing + (firstPoint.Northing - extendedStart.Northing) * f,
+                startHeading));
+        }
+        densified.AddRange(result); // keeps the original first/last points and the curve body
 
-        return result;
+        int tailSteps = Math.Max(1, (int)(extendEnd / extSpacing));
+        for (int i = 1; i <= tailSteps; i++)
+        {
+            double f = (double)i / tailSteps; // firstPoint-after-last → extended tip
+            densified.Add(new Vec3(
+                lastPoint.Easting + (extendedEnd.Easting - lastPoint.Easting) * f,
+                lastPoint.Northing + (extendedEnd.Northing - lastPoint.Northing) * f,
+                endHeading));
+        }
+
+        _logger.LogDebug($"[Curve] Extended start by {extendStart:F1}m, end by {extendEnd:F1}m (densified)");
+
+        return densified;
     }
 
     /// <summary>

--- a/Shared/AgOpenWeb.ViewModels/MainViewModel.Commands.Track.cs
+++ b/Shared/AgOpenWeb.ViewModels/MainViewModel.Commands.Track.cs
@@ -1399,38 +1399,57 @@ public partial class MainViewModel
             }
 
             var pts = boundary.Points;
-            int created = 0;
-            for (int i = 0; i < pts.Count; i++)
+            int n = pts.Count;
+
+            // Boundary points are densified along each straight edge, so one AB line PER POINT
+            // would make dozens on a 4-sided field. Find the CORNERS instead — vertices where the
+            // boundary direction turns sharply — and make one AB line per edge between corners.
+            const double CornerTurnThreshold = 0.35; // ~20°: real corners turn ~90°, edge noise <5°
+            var corners = new System.Collections.Generic.List<int>();
+            for (int i = 0; i < n; i++)
             {
-                int next = (i + 1) % pts.Count;
-                double dx = pts[next].Easting - pts[i].Easting;
-                double dy = pts[next].Northing - pts[i].Northing;
-                double dist = Math.Sqrt(dx * dx + dy * dy);
+                var prev = pts[(i - 1 + n) % n];
+                var cur = pts[i];
+                var nxt = pts[(i + 1) % n];
+                double hIn = Math.Atan2(cur.Easting - prev.Easting, cur.Northing - prev.Northing);
+                double hOut = Math.Atan2(nxt.Easting - cur.Easting, nxt.Northing - cur.Northing);
+                double turn = hOut - hIn;
+                while (turn > Math.PI) turn -= 2 * Math.PI;
+                while (turn < -Math.PI) turn += 2 * Math.PI;
+                if (Math.Abs(turn) > CornerTurnThreshold) corners.Add(i);
+            }
 
-                if (dist < 5.0) continue; // Skip tiny edges
-
-                double heading = Math.Atan2(dx, dy);
-                var a = new Models.Base.Vec3(
-                    pts[i].Easting - Math.Sin(heading) * 50,
-                    pts[i].Northing - Math.Cos(heading) * 50, heading);
-                var b = new Models.Base.Vec3(
-                    pts[next].Easting + Math.Sin(heading) * 50,
-                    pts[next].Northing + Math.Cos(heading) * 50, heading);
-
-                var track = new Models.Track.Track
+            int created = 0;
+            if (corners.Count >= 2)
+            {
+                // One AB line per edge: from each corner to the next, extended 50 m past both.
+                for (int k = 0; k < corners.Count; k++)
                 {
-                    Name = $"Edge {i + 1} ({dist:F0}m)",
-                    Points = new System.Collections.Generic.List<Models.Base.Vec3> { a, b },
-                    Type = Models.Track.TrackType.ABLine,
-                    IsVisible = true
-                };
-                SavedTracks.Add(track);
-                created++;
+                    var pa = pts[corners[k]];
+                    var pb = pts[corners[(k + 1) % corners.Count]];
+                    double dx = pb.Easting - pa.Easting, dy = pb.Northing - pa.Northing;
+                    double dist = Math.Sqrt(dx * dx + dy * dy);
+                    if (dist < 5.0) continue;
+
+                    double heading = Math.Atan2(dx, dy);
+                    var a = new Models.Base.Vec3(pa.Easting - Math.Sin(heading) * 50, pa.Northing - Math.Cos(heading) * 50, heading);
+                    var b = new Models.Base.Vec3(pb.Easting + Math.Sin(heading) * 50, pb.Northing + Math.Cos(heading) * 50, heading);
+                    SavedTracks.Add(new Models.Track.Track
+                    {
+                        Name = $"Edge {created + 1} ({dist:F0}m)",
+                        Points = new System.Collections.Generic.List<Models.Base.Vec3> { a, b },
+                        Type = Models.Track.TrackType.ABLine,
+                        IsVisible = true
+                    });
+                    created++;
+                }
             }
 
             if (created > 0)
                 SelectedTrack = SavedTracks[SavedTracks.Count - 1];
-            StatusMessage = $"Created {created} AB lines from boundary edges";
+            StatusMessage = created > 0
+                ? $"Created {created} AB lines from boundary edges"
+                : "Could not detect distinct boundary edges";
         });
 
         // Map zoom commands

--- a/Shared/AgOpenWeb.ViewModels/MainViewModel.GpsHandling.cs
+++ b/Shared/AgOpenWeb.ViewModels/MainViewModel.GpsHandling.cs
@@ -417,10 +417,13 @@ public partial class MainViewModel
         _gpsPipelineService.SetHeadlandLine(State.Field.HeadlandLine);
         _gpsPipelineService.SetDriftCompensation(State.Field.DriftEasting, State.Field.DriftNorthing);
         // Never arm U-turns on a closed/polygon track, regardless of the toggle (#421).
-        // Stopgap: also skip auto-U-turns on a boundary-follow (NoPassOffset) curve — auto
-        // arming is headland-proximity based and mis-fires on a line that hugs the boundary
-        // (fires at the first corner, return path outside the fence). Manual U-turns still work.
-        // Proper end-of-pass auto-U-turns for boundary curves are a separate follow-up.
+        // Stopgap: auto-U-turns are OFF on a boundary-follow (NoPassOffset) curve. Root cause:
+        // the arc only creates when the tractor is in the cultivated area (inside the headland
+        // line — synthetic when none defined, inset several m from the fence), but a fence-
+        // hugging pass sits INSIDE that band → never "cultivated" → no arc, it drives off the
+        // end. Proper fix = arm off the outer boundary / end-of-pass when there's no real
+        // headland. See continuation memory [[project_boundary_curve_uturn_continuation]].
+        // Manual U-turns + laterals still work on the boundary curve.
         _gpsPipelineService.SetYouTurnEnabled(
             IsYouTurnEnabled && !IsActiveTrackClosed && !(SelectedTrack?.NoPassOffset == true));
         _gpsPipelineService.SetYouTurnConfig(

--- a/Shared/AgOpenWeb.ViewModels/MainViewModel.GpsHandling.cs
+++ b/Shared/AgOpenWeb.ViewModels/MainViewModel.GpsHandling.cs
@@ -417,7 +417,12 @@ public partial class MainViewModel
         _gpsPipelineService.SetHeadlandLine(State.Field.HeadlandLine);
         _gpsPipelineService.SetDriftCompensation(State.Field.DriftEasting, State.Field.DriftNorthing);
         // Never arm U-turns on a closed/polygon track, regardless of the toggle (#421).
-        _gpsPipelineService.SetYouTurnEnabled(IsYouTurnEnabled && !IsActiveTrackClosed);
+        // Stopgap: also skip auto-U-turns on a boundary-follow (NoPassOffset) curve — auto
+        // arming is headland-proximity based and mis-fires on a line that hugs the boundary
+        // (fires at the first corner, return path outside the fence). Manual U-turns still work.
+        // Proper end-of-pass auto-U-turns for boundary curves are a separate follow-up.
+        _gpsPipelineService.SetYouTurnEnabled(
+            IsYouTurnEnabled && !IsActiveTrackClosed && !(SelectedTrack?.NoPassOffset == true));
         _gpsPipelineService.SetYouTurnConfig(
             UTurnSkipRows, IsSkipWorkedMode, HeadlandCalculatedWidth, HeadlandDistance);
     }

--- a/Shared/AgOpenWeb.ViewModels/MainViewModel.GpsHandling.cs
+++ b/Shared/AgOpenWeb.ViewModels/MainViewModel.GpsHandling.cs
@@ -417,15 +417,7 @@ public partial class MainViewModel
         _gpsPipelineService.SetHeadlandLine(State.Field.HeadlandLine);
         _gpsPipelineService.SetDriftCompensation(State.Field.DriftEasting, State.Field.DriftNorthing);
         // Never arm U-turns on a closed/polygon track, regardless of the toggle (#421).
-        // Stopgap: auto-U-turns are OFF on a boundary-follow (NoPassOffset) curve. Root cause:
-        // the arc only creates when the tractor is in the cultivated area (inside the headland
-        // line — synthetic when none defined, inset several m from the fence), but a fence-
-        // hugging pass sits INSIDE that band → never "cultivated" → no arc, it drives off the
-        // end. Proper fix = arm off the outer boundary / end-of-pass when there's no real
-        // headland. See continuation memory [[project_boundary_curve_uturn_continuation]].
-        // Manual U-turns + laterals still work on the boundary curve.
-        _gpsPipelineService.SetYouTurnEnabled(
-            IsYouTurnEnabled && !IsActiveTrackClosed && !(SelectedTrack?.NoPassOffset == true));
+        _gpsPipelineService.SetYouTurnEnabled(IsYouTurnEnabled && !IsActiveTrackClosed);
         _gpsPipelineService.SetYouTurnConfig(
             UTurnSkipRows, IsSkipWorkedMode, HeadlandCalculatedWidth, HeadlandDistance);
     }

--- a/Tests/AgOpenWeb.Services.Tests/YouTurn/BoundaryPassArmingTests.cs
+++ b/Tests/AgOpenWeb.Services.Tests/YouTurn/BoundaryPassArmingTests.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using AgOpenWeb.Models;
+using AgOpenWeb.Models.Base;
+using AgOpenWeb.Models.Configuration;
+using AgOpenWeb.Models.Pipeline;
+using AgOpenWeb.Models.State;
+using AgOpenWeb.Services.Geometry;
+using AgOpenWeb.Services.YouTurn;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+
+namespace AgOpenWeb.Services.Tests.YouTurn;
+
+/// <summary>
+/// Auto-U-turn arming on a fence-hugging boundary-follow pass in a field with NO real
+/// headland. The turn line is the AgOpen model: fence inset by uturnDistanceFromBoundary
+/// only (NOT turn-radius + distance). A pass offset ~half a tool width inside the fence
+/// therefore sits INSIDE the turn line → the tractor reads as "in the cultivated / in-turn
+/// area" → it arms through the ordinary path, no special-casing. This is the regression
+/// guard for the old bug where the synthetic line was inset by turnRadius + distance (~10 m),
+/// which put the boundary pass permanently OUTSIDE the band so it never armed.
+/// </summary>
+[TestFixture]
+[NonParallelizable]
+public class BoundaryPassArmingTests
+{
+    private const double ToolWidth = 6.0;
+    private const double HalfTool = ToolWidth / 2.0;
+    private const double DistFromBoundary = 2.0;
+
+    private YouTurnStateMachine _sm = null!;
+    private Boundary _boundary = null!;
+    private List<Vec3> _turnLine = null!;
+    private Models.Track.Track _track = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        ConfigurationStore.SetInstance(new ConfigurationStore());
+        var c = ConfigurationStore.Instance;
+        c.Vehicle.Wheelbase = 2.5;
+        c.Vehicle.MaxSteerAngle = 35;
+        c.Tool.Overlap = 0;
+        c.NumSections = 1;
+        c.Tool.SetSectionWidth(0, (int)(ToolWidth * 100)); // 6 m
+        c.Guidance.UTurnRadius = 8.0;
+        c.Guidance.UTurnExtension = 16.0;
+        c.Guidance.UTurnDistanceFromBoundary = DistFromBoundary;
+        c.Guidance.UTurnStyle = 0;
+
+        var offset = new PolygonOffsetService();
+        var creation = new YouTurnCreationService(NullLogger<YouTurnCreationService>.Instance, offset, c);
+        var pathing = new YouTurnPathingService(NullLogger<YouTurnPathingService>.Instance, c);
+        _sm = new YouTurnStateMachine(creation, pathing, NullLogger<YouTurnStateMachine>.Instance, c);
+
+        // 100 x 100 m field, fence at ±50.
+        var outer = new List<Vec2> { new(-50, -50), new(50, -50), new(50, 50), new(-50, 50) };
+        _boundary = new Boundary
+        {
+            OuterBoundary = new BoundaryPolygon
+            {
+                Points = outer.Select(p => new BoundaryPoint(p.Easting, p.Northing, 0)).ToList(),
+            },
+        };
+
+        // Turn line as the pipeline now builds it: fence inset by uturnDistanceFromBoundary
+        // = 2 m → square at ±48. (Pre-fix it was inset by 10 m → ±40, which excluded the pass.)
+        _turnLine = offset.CalculatePointHeadings(
+            offset.CreateInwardOffset(outer, DistFromBoundary)!);
+
+        // Fence-hugging boundary-follow pass along the WEST fence: x = -50 + halfTool = -47,
+        // heading due north. Inside the ±48 turn line (x = -47 > -48).
+        var curve = new List<Vec3>();
+        for (double y = -46; y <= 46 + 1e-9; y += 2.0)
+            curve.Add(new Vec3(-50 + HalfTool, y, 0));
+        _track = Models.Track.Track.FromCurve("bnd pass", curve);
+        _track.NoPassOffset = true;
+    }
+
+    private YouTurnStateMachine.TickContext MakeContext(double easting, double northing, double headingDeg)
+    {
+        var pos = new Position
+        {
+            Easting = easting,
+            Northing = northing,
+            Heading = headingDeg,
+            Speed = 2.78,
+        };
+        return new YouTurnStateMachine.TickContext(
+            pos, _track, _boundary, _turnLine,
+            UTurnSkipRows: 0, IsSkipWorkedMode: false,
+            HeadlandCalculatedWidth: DistFromBoundary, HeadlandDistance: 5.0);
+    }
+
+    [Test]
+    public void FenceHuggingPass_IsInsideTurnLine_AndArms()
+    {
+        var gState = new GuidanceWorkingState();
+        var tState = new YouTurnWorkingState { IsEnabled = true };
+
+        // Mid-pass, heading north along the west fence.
+        var ctx = MakeContext(-47, -20, 0);
+
+        List<Vec3>? armed = null;
+        for (int i = 0; i < 8 && armed == null; i++)
+        {
+            tState.YouTurnCounter++;
+            _sm.Tick(in ctx, gState, tState);
+            armed = tState.TurnPath;
+        }
+
+        Assert.That(tState.CurrentZone, Is.EqualTo(TractorZone.InCultivatedArea),
+            "the fence-hugging pass must read as inside the turn line (in-turn-bounds)");
+        Assert.That(armed, Is.Not.Null, "turn must arm through the normal cultivated-zone path");
+        Assert.That(armed!.Count, Is.GreaterThan(10));
+
+        // The next pass must be INWARD (east of the fence pass, toward the field).
+        Assert.That(tState.NextTrack, Is.Not.Null);
+        double avgNextEasting = tState.NextTrack!.Points.Average(p => p.Easting);
+        Assert.That(avgNextEasting, Is.GreaterThan(-47.0 + 1.0),
+            "next track must land on the inward side of the boundary pass");
+    }
+}

--- a/sys/version.h
+++ b/sys/version.h
@@ -5,7 +5,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 6
-#define VERSION_PATCH 66
+#define VERSION_PATCH 67
 
-#define VERSION "26.6.66"
+#define VERSION "26.6.67"
 #define VERSION_DATE "2026-07-01"

--- a/sys/version.h
+++ b/sys/version.h
@@ -5,7 +5,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 6
-#define VERSION_PATCH 65
+#define VERSION_PATCH 66
 
-#define VERSION "26.6.65"
+#define VERSION "26.6.66"
 #define VERSION_DATE "2026-07-01"

--- a/sys/version.h
+++ b/sys/version.h
@@ -5,7 +5,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 6
-#define VERSION_PATCH 67
+#define VERSION_PATCH 68
 
-#define VERSION "26.6.67"
-#define VERSION_DATE "2026-07-01"
+#define VERSION "26.6.68"
+#define VERSION_DATE "2026-07-02"

--- a/sys/version.h
+++ b/sys/version.h
@@ -5,7 +5,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 6
-#define VERSION_PATCH 68
+#define VERSION_PATCH 69
 
-#define VERSION "26.6.68"
+#define VERSION "26.6.69"
 #define VERSION_DATE "2026-07-02"


### PR DESCRIPTION
Promote `develop` → `main` for release **v26.6.69**.

## Included since v26.6.65 / last main
- **Boundary-curve auto-U-turns** (PR #58): work a field pass-by-pass following the fence in fields with no headland — arm off the outer-boundary turn line, densified end-extension past the fence, rounded offset corners, curve inset; plus count-down distance readout, All-Edges corner detection, and menu/HUD polish. Device-verified.
- **AB/track creation & guidance-line UX overhaul** (PR #57).

All tests green on develop. Version bumped to 26.6.69; tagging `v26.6.69` after merge triggers the release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)