### PR TITLE
Fix heading/camera mode button not responding on launcher (#56)

### DIFF
--- a/Shared/AgOpenWeb.RemoteServer/wwwroot/app.js
+++ b/Shared/AgOpenWeb.RemoteServer/wwwroot/app.js
@@ -3861,14 +3861,18 @@ function renderCampad() {
   const pad = document.getElementById('campad');
   if (!pad) return;
   pad.addEventListener('pointerdown', e => e.stopPropagation()); // don't pan the map
-  document.getElementById('cp-tiltup').addEventListener('click', () => { pitch = Math.max(0, pitch - PITCH_STEP); });
-  document.getElementById('cp-tiltdown').addEventListener('click', () => {
+  // Bind on POINTERDOWN, not click: the NativeWebView launcher (touch) doesn't reliably fire
+  // `click`, so these camera buttons — notably the mode/heading cycle — did nothing when tapped
+  // on the launcher build (issue #56). pointerdown is the same event the rest of the touch UI
+  // uses; the pad's stopPropagation above already keeps it from panning the map.
+  document.getElementById('cp-tiltup').addEventListener('pointerdown', () => { pitch = Math.max(0, pitch - PITCH_STEP); });
+  document.getElementById('cp-tiltdown').addEventListener('pointerdown', () => {
     pitch = Math.min(MAX_PITCH, pitch + PITCH_STEP);
   });
-  document.getElementById('cp-zoomin').addEventListener('click', () => { pxPerM = Math.min(200, pxPerM * 1.2); });
-  document.getElementById('cp-zoomout').addEventListener('click', () => { pxPerM = Math.max(0.2, pxPerM * 0.83); });
+  document.getElementById('cp-zoomin').addEventListener('pointerdown', () => { pxPerM = Math.min(200, pxPerM * 1.2); });
+  document.getElementById('cp-zoomout').addEventListener('pointerdown', () => { pxPerM = Math.max(0.2, pxPerM * 0.83); });
   // Center: cycle the four native modes H → N → M → C → H; recenter on follow modes.
-  document.getElementById('cp-mode').addEventListener('click', () => {
+  document.getElementById('cp-mode').addEventListener('pointerdown', () => {
     cameraMode = cameraMode === 1 ? 0 : cameraMode === 0 ? 3 : cameraMode === 3 ? 2 : 1;
     if (cameraMode !== 2) { const rp = renderPose(); if (rp) { camE = rp.e; camN = rp.n; } }
   });

--- a/sys/version.h
+++ b/sys/version.h
@@ -5,7 +5,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 6
-#define VERSION_PATCH 69
+#define VERSION_PATCH 70
 
-#define VERSION "26.6.69"
+#define VERSION "26.6.70"
 #define VERSION_DATE "2026-07-02"


### PR DESCRIPTION
Fixes #56 — tapping the heading/camera-mode button does nothing on the **launcher** (NativeWebView) build, though it works in a browser.

## Cause
The camera-panel buttons (mode/heading cycle, zoom, tilt) were bound on `click`. The NativeWebView launcher's touch handling doesn't reliably fire `click`, so the taps were dropped. The rest of the touch UI (bottom nav, sim bar, dialogs) uses `pointerdown`.

## Fix
Bind the five `#cp-*` camera buttons on `pointerdown` instead of `click`. The `#campad` container already calls `stopPropagation` on pointerdown, so this doesn't pan the map. Also fixes the zoom/tilt buttons, which had the same latent bug.

## Verification
JS syntax-checked. **Needs device verification on the launcher build** — the whole bug is launcher-touch-specific and can't be reproduced in a browser. Tapping the "M" button should cycle Heading-Up → North-Up → Map → Center.

v26.6.70.

🤖 Generated with [Claude Code](https://claude.com/claude-code)