### PR TITLE
Fix alert-sound burst on first UI click after startup

### DIFF
--- a/Shared/AgOpenWeb.RemoteServer/wwwroot/app.js
+++ b/Shared/AgOpenWeb.RemoteServer/wwwroot/app.js
@@ -356,9 +356,14 @@ const Sounds = (() => {
     if (unlocked) return;
     unlocked = true;
     // Nudge each element into a "played once" state so later programmatic play()
-    // (not tied to a gesture) is allowed by the autoplay policy.
+    // (not tied to a gesture) is allowed by the autoplay policy. Do it MUTED: the pause
+    // lands asynchronously in .then(), so an unmuted prime plays a burst of every alert
+    // audibly on the first UI click — notably the Hyd up/down 3-pt-hitch sounds. Muted
+    // playback still primes the element (and is always autoplay-allowed). Real plays clone
+    // the element, so they're unaffected by this temporary mute; restore it afterward anyway.
     for (const a of cache.values()) {
-      a.play().then(() => { a.pause(); a.currentTime = 0; }).catch(() => {});
+      a.muted = true;
+      a.play().then(() => { a.pause(); a.currentTime = 0; a.muted = false; }).catch(() => { a.muted = false; });
     }
     window.removeEventListener('pointerdown', unlock);
     window.removeEventListener('keydown', unlock);

--- a/sys/version.h
+++ b/sys/version.h
@@ -5,7 +5,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 6
-#define VERSION_PATCH 70
+#define VERSION_PATCH 71
 
-#define VERSION "26.6.70"
+#define VERSION "26.6.71"
 #define VERSION_DATE "2026-07-02"


### PR DESCRIPTION
On both headless and launcher, the first click on the UI after startup sometimes plays a burst of alert sounds — most audibly the Hyd up/down (3-pt-hitch) tones.

## Cause
The audio-unlock nudge primes each cached `<audio>` element for gesture-less autoplay by calling `play()` then pausing in an async `.then()`. Because the pause lands a beat after playback starts, the priming plays every alert audibly for a moment on the first pointer/key event. The Hyd up/down sounds are the distinctive ones. "Sometimes" is the timing race on how fast the pause lands.

## Fix
Prime the elements **muted** (`a.muted = true` before `play()`, restored after). Muted playback still satisfies the autoplay policy, so priming still works — it's just silent. Real alert plays clone the element, so they're unaffected by the temporary mute.

v26.6.71. Web-only (wwwroot); JS syntax-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)