### PR TITLE
Fix Windows-only test failures: profile file-lock and firewall-prompting sockets

### DIFF
--- a/Tests/AgOpenWeb.IntegrationTests/VirtualModules/VirtualGpsReceiver.cs
+++ b/Tests/AgOpenWeb.IntegrationTests/VirtualModules/VirtualGpsReceiver.cs
@@ -55,6 +55,10 @@ public class VirtualGpsReceiver : IDisposable
 
     public VirtualGpsReceiver(int targetPort = 9999, string targetIp = "127.0.0.1")
     {
+        // Send-only socket; leave it unbound so it lazily grabs an ephemeral port
+        // on first send. Outbound UDP does not trigger the Windows firewall prompt
+        // (only the listening modules do), and eager binding here would race the
+        // machine module for an ephemeral port in VirtualModuleHub.
         _udp = new UdpClient();
         _target = new IPEndPoint(IPAddress.Parse(targetIp), targetPort);
     }

--- a/Tests/AgOpenWeb.IntegrationTests/VirtualModules/VirtualMachineModule.cs
+++ b/Tests/AgOpenWeb.IntegrationTests/VirtualModules/VirtualMachineModule.cs
@@ -52,7 +52,9 @@ public class VirtualMachineModule : IDisposable
 
     public VirtualMachineModule(int listenPort = 8888, int hostPort = 9999, string hostIp = "127.0.0.1")
     {
-        _udp = new UdpClient(new IPEndPoint(IPAddress.Any, listenPort));
+        // Bind to loopback (not IPAddress.Any) so Windows Defender Firewall does
+        // not prompt during test runs. All virtual-module traffic is 127.0.0.1.
+        _udp = new UdpClient(new IPEndPoint(IPAddress.Loopback, listenPort));
         _hostEndpoint = new IPEndPoint(IPAddress.Parse(hostIp), hostPort);
     }
 

--- a/Tests/AgOpenWeb.IntegrationTests/VirtualModules/VirtualSteerModule.cs
+++ b/Tests/AgOpenWeb.IntegrationTests/VirtualModules/VirtualSteerModule.cs
@@ -128,7 +128,9 @@ public class VirtualSteerModule : IDisposable
 
     public VirtualSteerModule(int listenPort = 8888, int hostPort = 9999, string hostIp = "127.0.0.1")
     {
-        _udp = new UdpClient(new IPEndPoint(IPAddress.Any, listenPort));
+        // Bind to loopback (not IPAddress.Any) so Windows Defender Firewall does
+        // not prompt during test runs. All virtual-module traffic is 127.0.0.1.
+        _udp = new UdpClient(new IPEndPoint(IPAddress.Loopback, listenPort));
         _hostEndpoint = new IPEndPoint(IPAddress.Parse(hostIp), hostPort);
     }
 

--- a/Tests/AgOpenWeb.Services.Tests/ProfileJsonServiceV1Tests.cs
+++ b/Tests/AgOpenWeb.Services.Tests/ProfileJsonServiceV1Tests.cs
@@ -274,16 +274,14 @@ public class ProfileJsonServiceV1Tests
 
         // Reparse, remove the new fields properly, write back. Mirrors what an
         // older app build's saved profile would look like.
-        using (var src = System.IO.File.OpenRead(path))
-        {
-            var node = System.Text.Json.Nodes.JsonNode.Parse(src)!;
-            var toolObj = node["tool"]!.AsObject();
-            foreach (var k in droppedToolKeys) toolObj.Remove(k);
-            var guidanceObj = node["guidance"]!.AsObject();
-            foreach (var k in droppedGuidanceKeys) guidanceObj.Remove(k);
-            System.IO.File.WriteAllText(path, node.ToJsonString(
-                new System.Text.Json.JsonSerializerOptions { WriteIndented = true }));
-        }
+        var node = System.Text.Json.Nodes.JsonNode.Parse(
+            System.IO.File.ReadAllText(path))!;
+        var toolObj = node["tool"]!.AsObject();
+        foreach (var k in droppedToolKeys) toolObj.Remove(k);
+        var guidanceObj = node["guidance"]!.AsObject();
+        foreach (var k in droppedGuidanceKeys) guidanceObj.Remove(k);
+        System.IO.File.WriteAllText(path, node.ToJsonString(
+            new System.Text.Json.JsonSerializerOptions { WriteIndented = true }));
 
         var loadStore = new ConfigurationStore();
         ProfileJsonServiceV1.Load(_tempDir, "OldProfile", loadStore);


### PR DESCRIPTION
Two Windows-only test-suite fixes. Both are test-side only; no product code changes.

## 1. File-lock failure in `Load_OlderProfileWithoutNewFields_KeepsModelDefaults`
The test opened a read handle (`FileShare.Read`) on `OldProfile.json` and, while that handle was still open inside the `using` block, called `WriteAllText` on the same path. On Windows this deterministically fails with "process cannot access the file"; on Linux POSIX advisory locking lets the write through, which is why CI (ubuntu) never caught it. Read the file fully into a string and close the handle before writing back.

## 2. Windows Firewall prompt on every test run
`VirtualSteerModule` and `VirtualMachineModule` bound their listen sockets to `IPAddress.Any` (0.0.0.0), which makes Windows Defender Firewall prompt for network access. All virtual-module traffic is `127.0.0.1`, so bind the listeners to `IPAddress.Loopback` instead - loopback bypasses the firewall, no per-machine allow rule needed. The send-only GPS receiver is left as an unbound `UdpClient` (outbound UDP does not trigger the prompt, and eager binding would race the machine module for an ephemeral port in `VirtualModuleHub`).

## Testing
- Models: 146 passed
- Services: 1026 passed, 2 skipped
- ViewModels: 222 passed
- IntegrationTests: 9 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)