### PR TITLE
Fix linux headless service can not connect to UDP Modules input

### DIFF
--- a/deploy/linux/agopenweb.service
+++ b/deploy/linux/agopenweb.service
@@ -75,7 +75,8 @@ ProtectKernelTunables=true
 RestrictSUIDSGID=true
 # The .NET layer talks to modules over UDP (AF_INET) and to NTRIP over TCP; AF_UNIX
 # is used internally; AF_CAN is listed so a future SocketCAN path is not blocked.
-RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6 AF_CAN
+# AF_NETLINK is used by Linux and .NET to request for interfaces.
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6 AF_CAN AF_NETLINK
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Added  AF_NETLINK  to the restricted address-family allowlist in  agopenweb.service  so the Linux service can enumerate network interfaces.

## What changed

- Added  AF_NETLINK  to  RestrictAddressFamilies .
- This allows the headless AgOpenWeb service to access Linux Netlink sockets used for network-interface discovery.
- The service previously started normally but did not display network interfaces when installed through systemd; starting the project manually in debug mode was unaffected because it was not subject to the service sandbox restriction.
- The existing restrictions remain in place for  AF_CAN ,  AF_INET ,  AF_INET6 , and  AF_UNIX .