### PR TITLE
Fix UDP hello packet CRC byte

### DIFF
--- a/Shared/AgOpenWeb.Services/AutoSteer/PgnBuilder.cs
+++ b/Shared/AgOpenWeb.Services/AutoSteer/PgnBuilder.cs
@@ -374,6 +374,14 @@ public static class PgnBuilder
         => new byte[] { HEADER1, HEADER2, SOURCE, PgnNumbers.SCAN_REQUEST, 3, 202, 202, 5, 0x47 };
 
     /// <summary>
+    /// Build PGN 200 — the AgIO/AgOpenGPS "hello" packet modules watch for to
+    /// confirm the host is alive. Exact AgIO bytes:
+    /// { 0x80, 0x81, 0x7F, 200, 3, 56, 0, 0, 0x82 }.
+    /// </summary>
+    public static byte[] BuildHelloPacket()
+        => new byte[] { HEADER1, HEADER2, SOURCE, PgnNumbers.HELLO_FROM_AGIO, 3, 56, 0, 0, 0x82 };
+
+    /// <summary>
     /// Build PGN 201 — "set subnet" broadcast. Changes the first three IP octets
     /// (the /24) on ALL modules at once; the host octet is preserved by each
     /// module. There is no per-module selector — this is global, matching AgIO.

--- a/Shared/AgOpenWeb.Services/AutoSteer/PgnBuilder.cs
+++ b/Shared/AgOpenWeb.Services/AutoSteer/PgnBuilder.cs
@@ -371,7 +371,7 @@ public static class PgnBuilder
     /// { 0x80, 0x81, 0x7F, 202, 3, 202, 202, 5, 0x47 }.
     /// </summary>
     public static byte[] BuildScanRequest()
-        => new byte[] { HEADER1, HEADER2, SOURCE, PgnNumbers.SCAN_REQUEST, 3, 202, 202, 5, 0x47 };
+        => new byte[] { HEADER1, HEADER2, SOURCE, PgnNumbers.SCAN_REQUEST, 3, 202, 202, 5, 0xE5 };
 
     /// <summary>
     /// Build PGN 200 — the AgIO/AgOpenGPS "hello" packet modules watch for to

--- a/Shared/AgOpenWeb.Services/UdpCommunicationService.cs
+++ b/Shared/AgOpenWeb.Services/UdpCommunicationService.cs
@@ -60,9 +60,6 @@ public class UdpCommunicationService : IUdpCommunicationService, IDisposable
     private const int ModuleTimeoutSeconds = 5;
     private const int DiscoveryRefreshSeconds = 30;
 
-    // Hello packet: [0x80, 0x81, 0x7F, 200, 3, 56, 0, 0, CRC]
-    private readonly byte[] _helloPacket = { 0x80, 0x81, 0x7F, 200, 3, 56, 0, 0, 0x82 };
-
     // Module connection tracking - Hello responses (2 second timeout)
     private DateTime _lastHelloFromAutoSteer = DateTime.MinValue;
     private DateTime _lastHelloFromMachine = DateTime.MinValue;
@@ -233,7 +230,7 @@ public class UdpCommunicationService : IUdpCommunicationService, IDisposable
 
     public void SendHelloPacket()
     {
-        SendToModules(_helloPacket);
+        SendToModules(PgnBuilder.BuildHelloPacket());
     }
 
     public bool IsModuleHelloOk(ModuleType moduleType)

--- a/Shared/AgOpenWeb.Services/UdpCommunicationService.cs
+++ b/Shared/AgOpenWeb.Services/UdpCommunicationService.cs
@@ -61,7 +61,7 @@ public class UdpCommunicationService : IUdpCommunicationService, IDisposable
     private const int DiscoveryRefreshSeconds = 30;
 
     // Hello packet: [0x80, 0x81, 0x7F, 200, 3, 56, 0, 0, CRC]
-    private readonly byte[] _helloPacket = { 0x80, 0x81, 0x7F, 200, 3, 56, 0, 0, 0x47 };
+    private readonly byte[] _helloPacket = { 0x80, 0x81, 0x7F, 200, 3, 56, 0, 0, 0x82 };
 
     // Module connection tracking - Hello responses (2 second timeout)
     private DateTime _lastHelloFromAutoSteer = DateTime.MinValue;


### PR DESCRIPTION
Update the hardcoded hello packet in `UdpCommunicationService` to use the correct CRC (`0x82` instead of `0x47`). This ensures discovery hello broadcasts have a valid checksum so AgOpenGPS modules can recognize and respond reliably.
