### PR TITLE
Docs: GeoPackage storage analysis and coverage persistence plan

### DIFF
--- a/Plans/COVERAGE_TILED_PERSISTENCE_PLAN.md
+++ b/Plans/COVERAGE_TILED_PERSISTENCE_PLAN.md
@@ -1,0 +1,311 @@
+# Coverage Persistence: Tiled, Incremental, Atomic
+
+**Status:** Plan. Not started.
+**Decision context:** [GEOPACKAGE_STORAGE_ANALYSIS.md](GEOPACKAGE_STORAGE_ANALYSIS.md) §8.1 —
+GeoPackage adoption was rejected; this is the incremental fix to the existing
+file handling that the analysis recommended doing regardless.
+**Owner file:** `Shared/AgOpenWeb.Services/Coverage/CoverageMapService.cs`
+
+---
+
+## 1. Problem
+
+`MainViewModel.Autosave.cs` calls `_coverageMapService.SaveToFile(path, task)`
+**every 30 s** for the whole active job. That call rewrites both coverage
+files from scratch. Three distinct problems, in order of severity:
+
+### 1.1 `SaveSectionDisplay` rescans the entire detection grid every save
+
+This is the dominant cost and it is not the RLE. `SaveSectionDisplay`
+(`CoverageMapService.cs:1841`) does the following *on every autosave*:
+
+1. Allocates `new byte[pixels.Length]` — up to **25 MB** (`MAX_DISPLAY_PIXELS`
+   is 25 M), straight onto the LOH.
+2. Iterates **every byte** of `_detectionBits` — 65 MB of bytes for a 520 ha
+   field — and for each non-zero byte does 8 bit tests, coordinate math, and a
+   `Dictionary<ushort,byte>` lookup per set bit.
+
+On a well-covered 520 ha field that inner loop runs on the order of 5·10⁸
+iterations with a dictionary probe each, and allocates 25 MB, **every 30
+seconds**. This is what the code comment in `TryAutosaveCoverageAsync` is
+describing when it says *"RLE compression can take seconds on a large field."*
+The RLE is not the expensive part; the derive-indices-from-detection rescan is.
+
+The rescan exists only because the palette-index representation is never
+maintained — it is reconstructed from scratch at save time.
+
+### 1.2 Whole-file rewrite regardless of what changed
+
+Both `SaveDetectionBits` and `SaveSectionDisplay` serialise the complete grid.
+A 12 m tool at 10 km/h newly covers roughly 84 m × 12 m in a 30 s window —
+about **0.1 %** of a 520 ha field — yet we rewrite 100 % of both files. On the
+SD-card-backed Pi target this is also gratuitous write wear.
+
+### 1.3 Writes are not atomic, and two latent bugs
+
+- `FileMode.Create` truncate-then-write: a power cut mid-write leaves a
+  truncated or empty coverage file and the job's work is gone. The JSON paths
+  already solved this (`Storage/AtomicJsonFile.cs`); the coverage paths did not.
+- **Race:** the save runs on a thread-pool thread via `Task.Run` and reads
+  `_detectionBits` / `_displayPixels` **without holding `_coverageLock`**,
+  while the GPS/simulator thread is calling `MarkCellCovered`. `SetFieldBounds`
+  and `CheckAndExpandBounds` *reallocate* both arrays.
+- **Silent data loss:** `SaveSectionDisplay` compares `pixels.Length` against
+  `_displayWidth * _displayHeight` read separately. If `CheckAndExpandBounds`
+  fires between those two reads the check fails and the method **logs
+  "Pixel count mismatch" and returns without saving** — a silently skipped
+  autosave, exactly when the operator is driving near the field edge.
+
+### 1.4 Secondary: the RLE can expand
+
+The encoding is `[runLength:ushort][value:byte]` — **3 bytes per run**, with no
+raw fallback. Uniform regions compress hard, but a speckled region (partial
+section overlap, boundary feathering) degenerates to 3 bytes per byte — a **3x
+expansion** over the raw array. There is no per-block choice of raw vs RLE.
+
+---
+
+## 2. Non-goals
+
+- No new package dependencies. `AgOpenWeb.Services` stays fully managed
+  (this is the whole reason GeoPackage/SQLite was rejected).
+- No change to `ICoverageMapService`'s public surface
+  (`SaveToFile`/`LoadFromFile` keep their signatures) — this is a storage-layer
+  change, not an architecture change.
+- No change to the in-memory representation, the GL renderer's
+  `GetDisplayPixels`/`ConsumeDirtyRect` contract, or `CoverageProjector`'s
+  `_newCellsServer` drain.
+- Not touching the detection resolution ladder or `ComputeDisplayCellSize`.
+
+---
+
+## 3. Design
+
+### 3.1 A world-anchored tile grid
+
+Tiles are defined in **world space**, anchored at the plane origin, not at
+`_fieldMinE`/`_fieldMinN`:
+
+```
+TILE_METERS = 102.4                       // 1024 cells at BITMAP_CELL_SIZE (0.1 m)
+tileX = (int)Math.Floor(worldE / TILE_METERS)
+tileY = (int)Math.Floor(worldN / TILE_METERS)
+```
+
+Why world-anchored rather than buffer-relative: `CheckAndExpandBounds` moves
+`_bitmapOriginE`/`_fieldMinE` mid-job (it adds 250 m when coverage comes within
+50 m of an edge). A buffer-relative tile grid would renumber every tile on
+expansion and force a full rewrite — the exact thing we are removing. A
+world-anchored grid makes expansion a no-op for already-written tiles.
+
+One tile key addresses **both layers**:
+
+| Layer | Cells per tile | Raw bytes per tile |
+|---|---|---|
+| Detection @ 0.1 m fixed | 1024 x 1024 | 131 072 (1 bit/cell) |
+| Display @ `_displayCellSize` (0.1–1.0 m) | 1024 down to ~102 per side | 1 048 576 down to ~10 000 (1 byte index/px) |
+
+Tile size is the write-amplification knob: a 30 s window at 12 m / 10 km/h
+touches roughly 2–6 tiles, so an autosave writes ~0.3–1 MB instead of ~65 MB.
+1024 also keeps the file count sane — a 520 ha field is ~500 detection tiles,
+a typical 20 ha field is ~20.
+
+### 3.2 On-disk layout
+
+```
+jobs/<task>/coverage/
+├─ manifest.json          schemaVersion, displayCellSize, palette, worked area,
+│                         field bounds at save time, tile list
+├─ d/<tileX>_<tileY>.tile detection bits for that tile
+└─ s/<tileX>_<tileY>.tile display palette indices for that tile
+```
+
+One file per tile rather than a single container with an internal tile
+directory. A container would need free-space management and compaction when a
+recompressed tile no longer fits its old slot — that is re-implementing a
+database, which is what we just decided not to do. Per-tile files give atomic
+replace for free (`write .tmp` → `File.Move(..., overwrite: true)`), make a
+corrupt tile cost one tile rather than the job, and let a partial write be
+detected and discarded per tile.
+
+Tile header (both layers), 16 bytes:
+
+```
+magic      u32   'COVT'
+version    u8    1
+layer      u8    0 = detection, 1 = display
+encoding   u8    0 = raw, 1 = RLE          <- fixes §1.4
+reserved   u8
+cellSize   f32   metres per cell in this tile
+payloadLen u32
+crc32      u32   over payload             <- detects torn/truncated tiles
+```
+
+`encoding` is chosen per tile by encoding both ways and keeping the smaller —
+the tile is at most 1 MB, so this is cheap and removes the 3x pathological
+case permanently.
+
+`manifest.json` is written **last**, after every dirty tile has landed, and is
+written through `AtomicJsonFile`. It is the commit point: a manifest that
+references a tile is a promise that the tile is on disk and CRC-valid. A tile
+present on disk but absent from the manifest is ignored and cleaned up on next
+save.
+
+### 3.3 Dirty-tile tracking — needs new state
+
+**Correction to an assumption in the GeoPackage analysis:** neither existing
+piece of dirty state is reusable here.
+
+- `_dirtyMinX/_dirtyMaxX/...` is the **display-layer rect drained by the
+  renderer** — `ConsumeDirtyRect()` resets it every frame. The saver cannot
+  share it without starving the renderer or vice versa.
+- `_minCellE/_maxCellE/...` are **cumulative coverage bounds** (the extent of
+  all coverage ever), not "changed since last save".
+
+So add a third, independent stream, matching the existing precedent of
+`_newCells` (renderer) and `_newCellsServer` (web projector) being separate
+drains:
+
+```csharp
+// Tiles touched since the last successful save. Independent of the renderer's
+// ConsumeDirtyRect drain and the server's _newCellsServer drain — a save must
+// not steal dirty state from either. Mutated under _coverageLock.
+private readonly HashSet<long> _dirtyTiles = new();   // key = (tileX << 32) | (uint)tileY
+```
+
+Set in `MarkCellCovered` (which already runs under the lock and already
+computes the cell coordinates), cleared **only after the manifest commits**.
+A failed save therefore leaves the tiles dirty and the next autosave retries
+them — matching the "a failed autosave is a warning, not a fatal" comment in
+`TryAutosaveCoverageAsync`.
+
+### 3.4 Killing the rescan (the actual win)
+
+`SaveSectionDisplay`'s full-grid rescan disappears. Per dirty tile:
+
+1. Copy that tile's slice of `_displayPixels` (RGB565) into a **reused scratch
+   buffer** under `_coverageLock`, then release the lock.
+2. Convert RGB565 → palette index over the scratch buffer only.
+3. Encode + write.
+
+Cost per save becomes O(dirty tile area), not O(whole detection grid), and the
+25 MB per-save LOH allocation becomes one reused scratch buffer of at most
+~1 MB.
+
+The palette stops being discovered by scanning. Build it deterministically from
+config — `tool.GetSectionColor(0..15)` plus `tool.SingleCoverageColor`, which is
+already the first thing `SaveSectionDisplay` does — and keep
+`FindClosestColorIndex` as the fallback for any colour outside that set. Store
+it once in `manifest.json` instead of per file.
+
+### 3.5 Locking
+
+The scratch-copy in 3.4 fixes §1.3's race properly: short lock holds (one tile
+memcpy), compression and I/O outside the lock, and the length-mismatch check
+becomes impossible because tile geometry is derived from world coordinates
+inside the same lock that reads the pixels. Delete the silent
+`return`-on-mismatch path.
+
+### 3.6 Loading and back-compat
+
+`LoadFromFile` gains one preceding branch, and the existing fallback chain
+stays intact:
+
+```
+coverage/manifest.json present?          → tiled load (new)
+else coverage_detect.bin / _disp.bin?    → legacy binary load, then rewrite as tiles
+else Sections.txt?                       → existing AgOpenGPS import path
+```
+
+Reusing the one-way-import convention already used for `Sections.txt` and by
+`LegacyFieldMigrationService`: read the old format once, write the new one,
+leave the old file in place for one release, delete it in the release after.
+
+On tiled load, tiles whose CRC fails are skipped with a warning rather than
+failing the whole load — a torn tile costs ~1 ha of display coverage, not the
+job.
+
+---
+
+## 4. Work breakdown
+
+Each step is independently shippable and independently revertable.
+
+| # | Step | Files | Risk |
+|---|---|---|---|
+| 1 | **Measure first.** Add a stopwatch + byte-count log around `SaveDetectionBits`/`SaveSectionDisplay`; capture numbers on Pi and Tab S7 at ~20 ha, ~200 ha, ~520 ha. | `CoverageMapService.cs` | none |
+| 2 | Atomic writes for the two existing files (temp + `File.Move` overwrite). Ships the §1.3 durability fix immediately, independent of everything below. | `CoverageMapService.cs` | low |
+| 3 | Fix the silent skip: remove the mismatch `return`, take the pixel buffer and its dimensions under one lock. | `CoverageMapService.cs` | low |
+| 4 | Tile grid + `_dirtyTiles` set + `manifest.json` writer/reader. No behaviour change yet — write tiles *in addition to* the legacy files, compare on load in tests. | `CoverageMapService.cs`, new `Coverage/CoverageTileStore.cs` | med |
+| 5 | Per-tile encoder with raw-vs-RLE choice + CRC32. | `Coverage/CoverageTileStore.cs` | low |
+| 6 | Switch `SaveToFile` to dirty-tiles-only; delete the full-grid rescan from the display path; palette from config into the manifest. | `CoverageMapService.cs` | **high** — the hot path |
+| 7 | `LoadFromFile` branch order + one-way import from `coverage_*.bin`. | `CoverageMapService.cs` | med |
+| 8 | Stop writing the legacy `.bin` files. | `CoverageMapService.cs` | low |
+
+Steps 2 and 3 are worth landing on their own even if the rest slips — they are
+small and they fix real data-loss paths.
+
+---
+
+## 5. Testing
+
+Existing coverage tests are the regression harness and must keep passing
+unchanged through step 7:
+
+- `Tests/AgOpenWeb.Services.Tests/CoverageMapServicePerJobTests.cs` —
+  per-job isolation (`SaveToFile_TwoJobsSameField_DoNotShareCoverage`,
+  `LoadFromFile_PerJob_DoesNotPickUpFieldRootCoverage`).
+- `Tests/AgOpenWeb.Services.Tests/LegacyCoverageLoadTests.cs` —
+  `Sections.txt` import, `LoadFromFile_PrefersBinaryOverLegacy`, corrupt-file
+  tolerance.
+
+New tests:
+
+1. **Round-trip fidelity** — cover a known pattern, save, clear, load, assert
+   `IsPointCovered` matches cell-for-cell and `TotalWorkedArea` matches.
+2. **Only dirty tiles are written** — save, record tile mtimes, cover one
+   small area, save again, assert exactly the expected tile files changed.
+   This is the test that proves the whole plan works.
+3. **Expansion does not renumber tiles** — cover, save, drive past the edge to
+   trigger `CheckAndExpandBounds`, save, assert previously written tiles are
+   byte-identical and still referenced by the manifest.
+4. **Crash safety** — write a manifest referencing a tile, truncate that tile,
+   assert load skips it with a warning and keeps the rest.
+5. **Encoding choice** — a speckled tile picks `raw`, a uniform tile picks
+   `RLE`, and both round-trip.
+6. **Legacy import** — a `coverage_detect.bin` + `coverage_disp.bin` pair loads
+   and is rewritten as tiles; a second load reads the tiles.
+7. **Concurrency** — hammer `MarkCellCovered` on one thread while saving on
+   another; assert no exception and no lost coverage. This one is the reason
+   §3.5 exists.
+
+---
+
+## 6. Expected outcome
+
+| Metric | Now | Target |
+|---|---|---|
+| Autosave wall-clock, 520 ha | "seconds" (to be measured, step 1) | < 100 ms |
+| Bytes written per 30 s autosave | full grid (tens of MB) | ~0.3–1 MB |
+| Per-save LOH allocation | up to 25 MB | one reused ≤1 MB scratch |
+| Power-cut mid-write | job coverage lost | last committed manifest survives |
+| Save skipped during bounds expansion | silently, yes | no |
+| Worst-case encoded size | 3x raw | 1.0x raw |
+
+---
+
+## 7. Open questions
+
+1. **Step 1 gates the rest.** If the measured 520 ha autosave is already, say,
+   80 ms, steps 2–3 are still worth it for durability but 4–8 are not worth the
+   risk to the hot path. Measure before building.
+2. Is 102.4 m the right tile edge? Cross-check against the measured per-save
+   dirty area for a typical tool width and speed before committing to it — the
+   number should come from step 1's data, not from this document.
+3. Should `manifest.json` carry a monotonically increasing generation counter so
+   a stale tile from an interrupted save is detectable, or is CRC + "referenced
+   by manifest" sufficient? Leaning sufficient, but worth 10 minutes' thought
+   before step 4.
+4. Do we keep writing the legacy `.bin` files for one full release (step 8
+   deferred) to allow downgrade, given field data loss is unrecoverable?
+   Leaning yes.

--- a/Plans/GEOPACKAGE_STORAGE_ANALYSIS.md
+++ b/Plans/GEOPACKAGE_STORAGE_ANALYSIS.md
@@ -1,0 +1,326 @@
+# GeoPackage vs. Current File Formats — Storage Analysis
+
+**Status:** Decided — **GeoPackage rejected.** Options B, C and D below were all
+declined: marginal value against their implementation cost. §8.1 (fix coverage
+writes, no new dependency) was accepted and is planned in
+[COVERAGE_TILED_PERSISTENCE_PLAN.md](COVERAGE_TILED_PERSISTENCE_PLAN.md).
+The rest of this document is retained as the reasoning behind that call.
+
+**Related:** [FILE_FORMAT_MODERNIZATION_PLAN.md](FILE_FORMAT_MODERNIZATION_PLAN.md),
+[Completed/FIELDS_AND_JOBS_PLAN.md](Completed/FIELDS_AND_JOBS_PLAN.md),
+[../Docs/COVERAGE_PERFORMANCE_TESTS.md](../Docs/COVERAGE_PERFORMANCE_TESTS.md)
+
+---
+
+## 1. What we store today
+
+A field is a **directory of files**, not a single document. Current inventory as
+written by `Shared/AgOpenWeb.Services`:
+
+| Data | File | Format | Writer |
+|---|---|---|---|
+| Field metadata (id, name, origin, convergence) | `field.json` | JSON, schemaVersion 1 | `Fields/FieldJsonService.cs` |
+| Boundary + holes, headland, tracks, bg-image bounds | `field.geojson` | GeoJSON FeatureCollection (WGS84), `role` property per feature | `GeoJson/GeoJsonFieldService.cs` |
+| Field metadata (legacy mirror) | `Field.txt` | Fixed-line text | `FieldPlaneFileService.cs` |
+| Boundary (legacy mirror) | `Boundary.txt` | Point-list text | `BoundaryFileService.cs` |
+| Tracks | `TrackLines.txt` | Multi-line text blocks | `TrackFilesService.cs` |
+| Headland | `Headland.Txt`, `Headlines.txt`, `HeadlandSegments.json` | text + JSON | `HeadlandLineSerializer.cs`, `Headland/HeadlandSegmentFileService.cs` |
+| Tram lines | `TramLines.txt`, `TramConfig.json`, `TramSystems.json` | text + JSON | `Tram/*FileService.cs` |
+| Recorded path | `RecPath.txt` | text | `RecPathFileService.cs` |
+| Flags, contour, elevation | `Flags.txt`, `Contour.txt`, `Elevation.txt` | text | various |
+| Background imagery | `BackPic.png` + `BackPic.Txt` | PNG + bounds text | `BackgroundImageFileService.cs` |
+| **Coverage — detection** | `jobs/<task>/coverage_detect.bin` | `COVD`: header + RLE bit array @ 0.1 m | `Coverage/CoverageMapService.cs:1681` |
+| **Coverage — display** | `jobs/<task>/coverage_disp.bin` | `COVS`: header + ≤255-entry RGB565 palette + RLE byte indices | `Coverage/CoverageMapService.cs:1841` |
+| Coverage (legacy import) | `Sections.txt` | AgOpenGPS triangle strips | `CoverageMapService.LoadLegacySections` |
+| Job metadata | `jobs/<task>/job.json` | JSON, schemaVersion 1 | `Fields/JobJsonService.cs` |
+
+Two things follow from this table and matter for everything below:
+
+1. **GeoJSON is already the canonical vector format.** `FieldService.SaveField`
+   writes GeoJSON *and* mirrors legacy text; `LoadField` auto-converts legacy
+   fields to GeoJSON on first open. The AgOpenGPS-compat text files are a
+   deliberate interop mirror, not the source of truth.
+2. **The vector data is tiny; the coverage raster is not.** Boundaries and
+   tracks are hundreds to a few thousand points. Coverage detection for a
+   520 ha field is ~65 MB of bits at 0.1 m (`COVERAGE_PERFORMANCE_TESTS.md`),
+   which is why there is an adaptive resolution ladder (0.1 m at ≤50 ha,
+   1.0 m at 2812 ha+).
+
+---
+
+## 2. What GeoPackage actually is
+
+A `.gpkg` is a **SQLite 3 database** with `application_id = 'GPKG'` and a
+mandated set of metadata tables (`gpkg_spatial_ref_sys`, `gpkg_contents`,
+`gpkg_geometry_columns`). Vector features live in ordinary tables with a
+geometry column encoded as *GeoPackageBinary* — a small header (SRS id,
+optional envelope, flags) followed by standard WKB. Rasters live as a
+PNG/JPEG tile pyramid (`gpkg_tile_matrix_set` / `gpkg_tile_matrix`).
+Aspatial tables are legal (`data_type = 'attributes'`), and **arbitrary
+private tables are permitted** as long as they are not registered as GPKG
+content. Optional extensions add an R-Tree spatial index and, relevantly for
+us, **Tiled Gridded Coverage Data** (16-bit PNG or 32-bit float TIFF tiles).
+
+So "adopt GeoPackage" really means "adopt SQLite, plus the OGC table
+conventions on top of it." Those two halves have very different cost/benefit
+profiles and should be evaluated separately.
+
+---
+
+## 3. Fit, per data class
+
+### 3.1 Vector (boundary, headland, tracks, tram, flags, recpath) — weak case
+
+| Criterion | GeoJSON (today) | GeoPackage |
+|---|---|---|
+| QGIS / ArcGIS opens it | Yes, natively | Yes, natively |
+| Human-readable, greppable, git-diffable | Yes | No (binary) |
+| Field support debugging ("send me your field") | Paste a text file | Needs a tool to inspect |
+| Parse cost at our sizes | Negligible (<10 ms) | Negligible |
+| Typed schema / constraints | No | Yes |
+| Partial read / spatial index | No | Yes — **but we load the whole field into RAM anyway** |
+| Mixed geometry types in one layer | Yes | No — one geometry type per table |
+
+The classic database wins (indexed queries, partial reads, concurrent access)
+are **wasted here**. `MainViewModel` loads the entire field into plane
+coordinates and keeps it resident for guidance; nothing ever queries a subset.
+Meanwhile we would give up text-file debuggability, which has real support
+value for a user in a field whose only tool is a phone.
+
+Verdict: GPKG offers no meaningful advantage over GeoJSON for our vector data.
+
+### 3.2 Coverage raster — the real question, and GPKG answers it awkwardly
+
+This is where the current design genuinely hurts:
+
+- `TryAutosaveCoverageAsync` fires **every 30 s** and rewrites the *entire*
+  `coverage_detect.bin` and `coverage_disp.bin`. The code comment is candid:
+  *"RLE compression can take seconds on a large field."*
+- The RLE is `[runLength:ushort][value:byte]` — **3 bytes per run**. On uniform
+  data it compresses hard; on speckled data (partial section overlap, edge
+  cells) it can *expand up to 3x* versus the raw bit array. There is no
+  fallback to raw or to a real compressor.
+- Writes are `FileMode.Create` — truncate-then-write. A power cut mid-write on
+  a tractor leaves a corrupt or empty coverage file. (Contrast
+  `Storage/AtomicJsonFile.cs`, which the JSON paths already use.)
+- There is no "changed since last save" state to scope the write with.
+  `_minCellE`/`_maxCellE` are *cumulative* coverage bounds and the
+  `_dirtyMinX`/`_dirtyMaxX` rect is drained every frame by the renderer via
+  `ConsumeDirtyRect()`, so a saver needs its own dirty stream.
+- The dominant cost is not the RLE at all: `SaveSectionDisplay` rebuilds the
+  palette-index array from scratch on every save by scanning the entire
+  detection grid. See §1.1 of the coverage plan.
+
+A database would fix the incremental-write and durability problems. But
+**standard GeoPackage does not** give us a good home for this data:
+
+- *GPKG tiles* are PNG/JPEG images on a defined zoom pyramid in a declared CRS.
+  Our detection layer is a 1-bit semantic mask at a metric cell size tied to
+  the field's local plane, not a display pyramid. Shoehorning it in means
+  inventing a tile matrix set per field and paying PNG encode/decode on the
+  30 s autosave path — worse than the RLE we have.
+- *Tiled Gridded Coverage* is designed for continuous values (elevation),
+  16-bit PNG or float TIFF. Our detection bits are boolean and our display
+  layer is a palette index. Neither is what the extension models.
+- The honest answer is a **private blob table**
+  (`coverage_tiles(job, tx, ty, blob)`) inside the SQLite file — legal in a
+  GPKG, but at that point GeoPackage contributes nothing except the file
+  extension.
+
+Verdict: the coverage problem is a *chunked, transactional write* problem.
+SQLite solves it. GeoPackage-the-standard adds nothing to that solve.
+
+### 3.3 Background imagery — mild case for GPKG tiles
+
+`BackPic.png` + a bounds text file is exactly what `gpkg_tile_matrix` exists to
+replace, and it would scale to multi-tile imagery if we ever want more than one
+capture. Low priority; the current single-PNG approach is not causing pain.
+
+### 3.4 Metadata / config — no change either way
+
+JSON is correct for `field.json`, `job.json`, `appsettings.json`.
+
+---
+
+## 4. Cost of adoption
+
+### 4.1 New dependency: SQLite on five heads
+
+We currently ship **zero native dependencies** in `AgOpenWeb.Services`
+(`Newtonsoft.Json`, `Dev4Agriculture.ISO11783.ISOXML`, `Clipper2`,
+`Microsoft.Extensions.Logging.Abstractions` — all managed). Adding
+`Microsoft.Data.Sqlite` pulls in `SQLitePCLRaw` and a native `e_sqlite3` per
+RID. Consequences:
+
+- **Desktop** (win-x64, linux-x64, linux-arm64, osx): fine, but the
+  `deploy/{linux,windows,macos}/package.sh` scripts must carry the extra
+  native asset per RID.
+- **Android**: must ship bundled `e_sqlite3` (the system SQLite is not usable
+  under that name on Android). APK grows.
+- **iOS**: works in principle, but this is the head where Release/AOT is
+  already fragile — `CLAUDE.md` notes *"iOS Release builds hang in CI; use
+  Debug."* Adding a native P/Invoke library to that build is where surprises
+  live.
+- The `RTREE` and WAL behaviours we would rely on need verifying per bundle,
+  not assuming.
+
+### 4.2 No usable managed GeoPackage library
+
+`NetTopologySuite.IO.GeoPackage` — the obvious candidate — is at **2.0.0,
+released August 2019**, and is essentially the GeoPackageBinary geometry codec,
+not a container manager. `SpatialFocus.GeoPackage` is alpha. GDAL bindings
+(`MaxRev.Gdal.Core`) are tens of MB of native code and a non-starter for
+iOS/Android here.
+
+So the realistic path is **hand-rolling the GPKG container** over
+`Microsoft.Data.Sqlite`: the metadata tables, the SRS rows, the geometry
+header, the `gpkg_contents` bookkeeping, and validation against the spec. That
+is a few hundred lines of code we own forever, plus the risk that a subtle spec
+violation produces files QGIS opens but a customer's FMS rejects.
+
+### 4.3 Migration and churn
+
+The GeoJSON canonical format landed recently and legacy auto-conversion
+(`FieldService.LoadField`, `LegacyFieldMigrationService`) already carries two
+eras of format. A third canonical format means a third migration path and
+another round of "which of these files is authoritative" bugs — the exact class
+of bug the Fields/Jobs split (#349) just cleaned up.
+
+### 4.4 Loss of failure transparency
+
+A directory of files degrades gracefully: a corrupt `TramLines.txt` costs you
+tram lines, not the field. A corrupt SQLite header costs you *everything* for
+that field — boundary, tracks, and every job's coverage. A single-file
+container needs an explicit answer here: backup-on-open, `PRAGMA
+integrity_check`, or keeping coverage outside the container.
+
+---
+
+## 5. What GeoPackage would genuinely buy
+
+Being fair to the proposal, these are real:
+
+1. **One file per field.** Emailing or USB-sticking a field becomes trivial
+   versus zipping a directory of ~12 files. Good UX, and good for
+   AgShare-adjacent workflows.
+2. **Transactional, incremental writes.** The 30 s coverage autosave becomes a
+   handful of dirty-tile UPDATEs inside a transaction instead of a multi-MB
+   full rewrite. Crash-safe by construction. This is the single biggest
+   technical win — and it comes from *SQLite*, not from *GeoPackage*.
+3. **Typed schema with constraints**, replacing per-file ad-hoc parsers.
+4. **Direct GIS ingest** with no export step: drop the field on QGIS, get
+   boundary/headland/tracks as named layers with attributes.
+5. **A natural home for job history.** Many jobs per field accumulating
+   as-applied coverage is a database-shaped problem.
+
+---
+
+## 6. Interop reality check
+
+| Consumer | GeoJSON | GeoPackage | Notes |
+|---|---|---|---|
+| QGIS / ArcGIS / GDAL | yes | yes | Both first-class |
+| AgOpenGPS (desktop) | no | no | Needs the legacy `.txt` mirror either way |
+| AgShare | yes (JSON API) | no | `AgShareUploaderService` posts JSON |
+| ISO 11783 / ISOXML | n/a | n/a | Separate exporter (`IsoXml/IsoXmlExporter.cs`) |
+| Farm management systems (Ops Center, FieldView, Trimble) | partial | **verify** | These predominantly ingest shapefile + ISOXML; GPKG support is inconsistent. Confirm before claiming GPKG improves FMS interop. |
+
+Note the shape of this table: **GPKG does not unlock any consumer we cannot
+already reach.** Its advantage over GeoJSON is convenience (one file, typed
+layers), not reach.
+
+---
+
+## 7. Options
+
+**A. Status quo.** Keep GeoJSON + JSON + `.bin` coverage.
+*Cost:* zero. *Leaves unfixed:* the coverage full-rewrite and non-atomic-write
+problems, and no single-file field.
+
+**B. GeoPackage as an import/export format only.** Canonical storage unchanged;
+add `ExportFieldToGeoPackage` / `ImportFieldFromGeoPackage` alongside the
+existing ISOXML exporter.
+*Cost:* SQLite dependency + ~400 lines of container code, but **zero migration
+risk** and no hot-path exposure. Export can ship Desktop-only at first,
+sidestepping the iOS/Android AOT question entirely.
+*Gets:* interop convenience, single-file sharing. *Does not get:* the coverage
+write fix.
+
+**C. GeoPackage canonical for vector, coverage stays `.bin`.**
+*Cost:* full migration path, loses text debuggability.
+*Gets:* very little that B does not. **Worst ratio of the four.**
+
+**D. Single SQLite container per field — GPKG-compliant for vector layers,
+private tables for coverage.** Boundary/headland/tracks/flags as real GPKG
+feature tables (so QGIS just works), coverage as a tiled blob table, metadata
+as attributes tables.
+*Cost:* highest — SQLite on all five heads, hand-rolled container, full
+migration, corruption blast-radius answer required.
+*Gets:* everything in §5 at once, including the coverage write fix.
+
+---
+
+## 8. Recommendation
+
+**Split the decision. The coverage problem is urgent and is not a GeoPackage
+problem; the GeoPackage question is a nice-to-have and is not urgent.**
+
+1. **Fix coverage writes independently of this decision.** Chunk
+   `coverage_detect.bin` / `coverage_disp.bin` into world-anchored tiles, track
+   dirty tiles, stop rebuilding the palette-index array from a full-grid scan
+   on every save, and write atomically (temp + rename, as `AtomicJsonFile`
+   does). While in there, add a raw-vs-RLE choice per tile so speckled tiles
+   stop expanding 3x. This removes the "seconds on a large field" autosave
+   stall and the power-cut corruption window **with no new dependency**.
+   → **Accepted.** Planned in
+   [COVERAGE_TILED_PERSISTENCE_PLAN.md](COVERAGE_TILED_PERSISTENCE_PLAN.md).
+
+2. ~~Take Option B for GeoPackage: export/import only.~~
+   → **Declined.** The benefit is a QGIS/single-file convenience that no
+   consumer in §6 actually requires, against a SQLite native dependency, a
+   hand-rolled container, and ongoing spec-compliance risk.
+
+3. ~~Do not make GeoPackage canonical now.~~
+   → **Declined outright**, not merely deferred. GeoJSON reaches every consumer
+   GPKG reaches and text-file debuggability has real field-support value.
+
+---
+
+## 9. If Option B proceeds — sketch
+
+```
+field.gpkg
+├─ gpkg_spatial_ref_sys        EPSG:4326
+├─ gpkg_contents               one row per layer below
+├─ gpkg_geometry_columns
+├─ boundary        POLYGON     role, isHard, isDriveThrough, area_ha
+├─ headland        POLYGON     source ('offset' | 'drawn')
+├─ tracks          LINESTRING  name, mode, isClosed, nudge_m, noPassOffset
+├─ tram_lines      LINESTRING  system, index
+├─ flags           POINT       name, color, note
+└─ field_meta      attributes  id, name, originLat, originLon, convergence,
+                               offsetX/Y, created, modified, schemaVersion
+```
+
+Coordinates in EPSG:4326, converted via the existing `GeoConversion` on the way
+out and back — identical to what `GeoJsonFieldService` already does, so the
+conversion code is reusable and only the encoding layer is new.
+
+Coverage is deliberately **excluded** from the export in Option B. If we later
+want as-applied maps in the file, the correct standard-compliant answer is a
+vectorised coverage polygon layer (Clipper2 is already a dependency and can
+union the worked area), *not* the raw detection bitmap — a vector as-applied
+map is what an agronomist or FMS actually wants to consume.
+
+---
+
+## 10. Open questions — resolved by the decision
+
+1. What is the *measured* autosave cost today on the Pi and Tab S7 targets at
+   520 ha? → Still open, now the **first step** of the coverage plan.
+2. How often does the RLE actually expand rather than compress on real field
+   data? → Still open, folded into the same measurement step.
+3. Do the FMS platforms our users care about ingest GPKG? → Moot; GPKG declined.
+4. Does `e_sqlite3` build cleanly under the iOS AOT path? → Moot; no SQLite.
+5. Is anyone asking for single-file fields? → Not currently; revisit only if
+   that demand materialises.


### PR DESCRIPTION
Two planning documents. No code changes.

## `Plans/GEOPACKAGE_STORAGE_ANALYSIS.md`

Evaluates GeoPackage (`.gpkg`) as a replacement for the current text/binary field storage, and **recommends against it**. The reasoning, in short:

- GeoPackage is SQLite plus OGC table conventions, and the two halves need judging separately.
- Our vector data (boundaries, tracks, headland) is small and fully resident in RAM for guidance, so indexed and partial reads — the main thing a database buys — are wasted. GeoJSON already reaches every consumer GPKG reaches.
- The coverage raster is the only heavy data, and standard GPKG has no good home for a 1-bit semantic mask on a local metric plane. The tiles extension is a display pyramid; Tiled Gridded Coverage models continuous values like elevation.
- Adoption would mean a native SQLite dependency across all five platform heads — including the iOS AOT path that already hangs in CI on Release — plus a hand-rolled container, since `NetTopologySuite.IO.GeoPackage` is a 2019 geometry codec rather than a container manager.

The document records the decision and the options that were declined, so the question doesn't get re-litigated from scratch later.

## `Plans/COVERAGE_TILED_PERSISTENCE_PLAN.md`

The analysis recommended one thing worth doing regardless of the GeoPackage verdict: fix how coverage is written. This plans that work.

Reading `CoverageMapService` closely turned up that **the dominant autosave cost is not the RLE**. `SaveSectionDisplay` rebuilds the palette-index array from scratch every 30 s by scanning the whole detection grid — on the order of 5·10⁸ iterations plus a 25 MB LOH allocation on a 520 ha field. That is what the "seconds on a large field" comment in `TryAutosaveCoverageAsync` is describing.

The plan proposes a world-anchored tile grid (so `CheckAndExpandBounds` moving `_fieldMinE` mid-job cannot renumber tiles), dirty-tile tracking in a stream independent of the renderer's `ConsumeDirtyRect` and the web projector's `_newCellsServer` drains, per-tile raw-vs-RLE encoding with a CRC, and a manifest written last as the commit point.

It also records two latent bugs found while reading:

- The save runs on a thread-pool thread and reads `_detectionBits` / `_displayPixels` off `_coverageLock`, while the GPS thread may reallocate them via `CheckAndExpandBounds`.
- If a bounds expansion races the save, `SaveSectionDisplay` logs "Pixel count mismatch" and **returns without saving** — a silently skipped autosave, precisely when the operator is driving near the field edge.

Step 1 of the plan is *measure first*, and it says explicitly that if the measured 520 ha autosave turns out to be fast, the later tiling steps are not worth the risk to that hot path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0133r866nfGcmeM3vabzrYRj
