### PR TITLE
Send computed PGN checksums instead of AgIO's placeholder (builds on #72)

### DIFF
--- a/Shared/AgOpenWeb.Services/AutoSteer/PgnBuilder.cs
+++ b/Shared/AgOpenWeb.Services/AutoSteer/PgnBuilder.cs
@@ -168,10 +168,7 @@ public static class PgnBuilder
             buf[12] = (byte)((state.SectionStates >> 8) & 0xFF);  // Sections 9-16
         }
 
-        // CRC: sum of bytes 2 through 12 (source through last data byte)
-        buf[13] = CalculateCrc(buf, 2, 11);
-
-        return buf;
+        return WithCrc(buf);
     }
 
     /// <summary>
@@ -225,10 +222,7 @@ public static class PgnBuilder
         buf[11] = (byte)(state.SectionStates & 0xFF);         // Sections 1-8
         buf[12] = (byte)((state.SectionStates >> 8) & 0xFF);  // Sections 9-16
 
-        // CRC
-        buf[13] = CalculateCrc(buf, 2, 11);
-
-        return buf;
+        return WithCrc(buf);
     }
 
     /// <summary>
@@ -271,10 +265,7 @@ public static class PgnBuilder
         buf[13] = speed;
         buf[14] = speed;
 
-        // CRC: sum of bytes 2 through 14 (source through last data byte)
-        buf[15] = CalculateCrc(buf, 2, 13);
-
-        return buf;
+        return WithCrc(buf);
     }
 
     /// <summary>
@@ -315,8 +306,7 @@ public static class PgnBuilder
         buf[11] = (byte)Math.Clamp(config.User3Value, 0, 255);
         buf[12] = (byte)Math.Clamp(config.User4Value, 0, 255);
 
-        buf[13] = CalculateCrc(buf, 2, 11);
-        return buf;
+        return WithCrc(buf);
     }
 
     /// <summary>
@@ -341,8 +331,7 @@ public static class PgnBuilder
             buf[5 + i] = (byte)(i < pins.Length ? pins[i] : 0);
         }
 
-        buf[29] = CalculateCrc(buf, 2, 27);
-        return buf;
+        return WithCrc(buf);
     }
 
     /// <summary>
@@ -359,28 +348,63 @@ public static class PgnBuilder
         return crc;
     }
 
+    /// <summary>
+    /// Stamp the trailing CRC into a fully-populated packet and return it. The
+    /// last byte is the sum of bytes [2 .. len-2] (source through last data
+    /// byte), matching <see cref="CalculateCrc"/> and PgnMessage.CalculateCRC.
+    /// </summary>
+    /// <remarks>
+    /// Every builder in this class returns through here, so the CRC offset and
+    /// span are derived from the buffer length instead of being hand-written per
+    /// PGN. That removes the failure mode where a packet grows a data byte and
+    /// its checksum keeps summing the old span. Operates in place — safe for the
+    /// pooled buffers the hot-path builders reuse.
+    /// </remarks>
+    private static byte[] WithCrc(byte[] packet)
+    {
+        packet[^1] = CalculateCrc(packet, 2, packet.Length - 3);
+        return packet;
+    }
+
     // ===== Module network config (AgIO parity: FormUDP.cs / UDP.designer.cs) =====
-    // These reproduce AgIO's exact wire bytes so the existing AiO board install
-    // base responds correctly. AgIO hardcodes the trailing CRC byte (0x47) for
-    // the scan (202) and set-subnet (201) packets and the modules validate only
-    // the magic bytes (data[5]/[6]), not the CRC — so we keep 0x47 verbatim.
+    // The layouts below reproduce AgIO's wire format so the existing AiO board
+    // install base responds correctly. AgIO itself leaves a stale placeholder
+    // (0x47) in the trailing CRC slot and never recomputes it — UDP.designer.cs:82
+    // rewrites helloFromAgIO[5] and leaves the checksum untouched. Modules gate on
+    // the header + PGN + magic bytes (data[5]/[6]) and ignore the CRC, which is why
+    // that placeholder has always been accepted. We send a correctly computed CRC
+    // instead: firmware that ignores the byte is unaffected, and firmware that does
+    // verify it now passes rather than relying on luck.
+    //
+    // This is send-side only. Do NOT gate the inbound path on ValidateChecksum:
+    // some modules transmit a placeholder CRC of their own, and rejecting those
+    // packets takes the whole link down.
 
     /// <summary>
     /// Build PGN 202 — "scan request" broadcast that asks every module to reply
-    /// with its IP/subnet (PGN 203). Exact AgIO bytes:
-    /// { 0x80, 0x81, 0x7F, 202, 3, 202, 202, 5, 0x47 }.
+    /// with its IP/subnet (PGN 203). AgIO layout (FormUDP.cs:137) with a computed
+    /// CRC: { 0x80, 0x81, 0x7F, 202, 3, 202, 202, 5, CRC }.
     /// </summary>
     public static byte[] BuildScanRequest()
-        => new byte[] { HEADER1, HEADER2, SOURCE, PgnNumbers.SCAN_REQUEST, 3, 202, 202, 5, 0x47 };
+        => WithCrc(new byte[] { HEADER1, HEADER2, SOURCE, PgnNumbers.SCAN_REQUEST, 3, 202, 202, 5, 0 });
+
+    /// <summary>
+    /// Build PGN 200 — the "hello" packet modules watch for to confirm the host is
+    /// alive. AgIO layout (UDP.designer.cs:76) with a computed CRC:
+    /// { 0x80, 0x81, 0x7F, 200, 3, 56, 0, 0, CRC }.
+    /// </summary>
+    public static byte[] BuildHelloPacket()
+        => WithCrc(new byte[] { HEADER1, HEADER2, SOURCE, PgnNumbers.HELLO_FROM_AGIO, 3, 56, 0, 0, 0 });
 
     /// <summary>
     /// Build PGN 201 — "set subnet" broadcast. Changes the first three IP octets
     /// (the /24) on ALL modules at once; the host octet is preserved by each
     /// module. There is no per-module selector — this is global, matching AgIO.
-    /// Exact AgIO bytes: { 0x80, 0x81, 0x7F, 201, 5, 201, 201, o1, o2, o3, 0x47 }.
+    /// AgIO layout (FormUDP.cs:19) with a computed CRC:
+    /// { 0x80, 0x81, 0x7F, 201, 5, 201, 201, o1, o2, o3, CRC }.
     /// </summary>
     public static byte[] BuildSubnetChange(byte octet1, byte octet2, byte octet3)
-        => new byte[] { HEADER1, HEADER2, SOURCE, PgnNumbers.SET_SUBNET, 5, 201, 201, octet1, octet2, octet3, 0x47 };
+        => WithCrc(new byte[] { HEADER1, HEADER2, SOURCE, PgnNumbers.SET_SUBNET, 5, 201, 201, octet1, octet2, octet3, 0 });
 
     /// <summary>
     /// Parse a PGN 203 scan reply (13 bytes): module id at [2], full module IP at
@@ -404,18 +428,26 @@ public static class PgnBuilder
     }
 
     /// <summary>
-    /// Validate a received PGN checksum.
+    /// Validate a received PGN checksum using the same rule the send path uses:
+    /// the trailing byte is the sum of bytes [2 .. len-2]. (This previously XOR'd
+    /// bytes [0 .. len-2], which disagreed with every packet this class builds and
+    /// would have rejected all valid traffic.)
+    ///
+    /// Diagnostics only — deliberately NOT wired into the receive path. Real
+    /// modules ship packets carrying a placeholder CRC, so gating inbound handling
+    /// on this would drop legitimate traffic and break communications.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool ValidateChecksum(ReadOnlySpan<byte> data)
     {
-        if (data.Length < 2) return false;
+        // header(2) + source + pgn + len + crc
+        if (data.Length < 6) return false;
 
         int checksumPos = data.Length - 1;
         byte calculated = 0;
-        for (int i = 0; i < checksumPos; i++)
+        for (int i = 2; i < checksumPos; i++)
         {
-            calculated ^= data[i];
+            calculated += data[i];
         }
         return calculated == data[checksumPos];
     }
@@ -470,10 +502,7 @@ public static class PgnBuilder
         // Ackermann correction (0-200)
         buf[12] = (byte)Math.Clamp(config.Ackermann, 0, 200);
 
-        // CRC
-        buf[13] = CalculateCrc(buf, 2, 11);
-
-        return buf;
+        return WithCrc(buf);
     }
 
     /// <summary>
@@ -526,10 +555,7 @@ public static class PgnBuilder
         // Angular velocity (not currently used, set to 0)
         buf[9] = 0;
 
-        // CRC
-        buf[10] = CalculateCrc(buf, 2, 8);
-
-        return buf;
+        return WithCrc(buf);
     }
 
     #region PGN 253 Parser (Steer Data FROM Module)

--- a/Shared/AgOpenWeb.Services/UdpCommunicationService.cs
+++ b/Shared/AgOpenWeb.Services/UdpCommunicationService.cs
@@ -60,9 +60,6 @@ public class UdpCommunicationService : IUdpCommunicationService, IDisposable
     private const int ModuleTimeoutSeconds = 5;
     private const int DiscoveryRefreshSeconds = 30;
 
-    // Hello packet: [0x80, 0x81, 0x7F, 200, 3, 56, 0, 0, CRC]
-    private readonly byte[] _helloPacket = { 0x80, 0x81, 0x7F, 200, 3, 56, 0, 0, 0x47 };
-
     // Module connection tracking - Hello responses (2 second timeout)
     private DateTime _lastHelloFromAutoSteer = DateTime.MinValue;
     private DateTime _lastHelloFromMachine = DateTime.MinValue;
@@ -233,7 +230,7 @@ public class UdpCommunicationService : IUdpCommunicationService, IDisposable
 
     public void SendHelloPacket()
     {
-        SendToModules(_helloPacket);
+        SendToModules(PgnBuilder.BuildHelloPacket());
     }
 
     public bool IsModuleHelloOk(ModuleType moduleType)

--- a/Tests/AgOpenWeb.Services.Tests/ModuleNetworkPgnTests.cs
+++ b/Tests/AgOpenWeb.Services.Tests/ModuleNetworkPgnTests.cs
@@ -17,14 +17,60 @@ namespace AgOpenWeb.Services.Tests;
 [TestFixture]
 public class ModuleNetworkPgnTests
 {
+    /// <summary>
+    /// Reference CRC: sum of bytes [2 .. len-2], mod 256 — the rule every
+    /// PgnBuilder send path uses. Computed here independently of the production
+    /// helper so the tests would catch a change to that helper.
+    /// </summary>
+    private static byte ExpectedCrc(params int[] packetWithoutCrc)
+    {
+        int sum = 0;
+        for (int i = 2; i < packetWithoutCrc.Length; i++) sum += packetWithoutCrc[i];
+        return (byte)(sum & 0xFF);
+    }
+
     // ===== PGN 202 — scan request =====
 
     [Test]
-    public void BuildScanRequest_MatchesAgIoBytesExactly()
+    public void BuildScanRequest_MatchesAgIoLayout_WithComputedCrc()
     {
-        // AgIO FormUDP.cs:137 — { 0x80, 0x81, 0x7F, 202, 3, 202, 202, 5, 0x47 }
-        var expected = new byte[] { 0x80, 0x81, 0x7F, 202, 3, 202, 202, 5, 0x47 };
+        // AgIO FormUDP.cs:137 uses this layout but ships a stale placeholder
+        // (0x47) in the CRC slot and never recomputes it. Modules ignore the
+        // byte, so we send the real checksum instead.
+        var expected = new byte[]
+        {
+            0x80, 0x81, 0x7F, 202, 3, 202, 202, 5,
+            ExpectedCrc(0x80, 0x81, 0x7F, 202, 3, 202, 202, 5)
+        };
         Assert.That(PgnBuilder.BuildScanRequest(), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void BuildScanRequest_CrcIsNotTheAgIoPlaceholder()
+    {
+        // 0xE5, not 0x47 — guards against the hardcoded byte creeping back.
+        Assert.That(PgnBuilder.BuildScanRequest()[^1], Is.EqualTo(0xE5));
+    }
+
+    // ===== PGN 200 — hello from AgIO =====
+
+    [Test]
+    public void BuildHelloPacket_MatchesAgIoLayout_WithComputedCrc()
+    {
+        // AgIO UDP.designer.cs:76 layout; :82 rewrites byte[5] without
+        // recomputing the checksum, which is why its 0x47 is meaningless.
+        var expected = new byte[]
+        {
+            0x80, 0x81, 0x7F, 200, 3, 56, 0, 0,
+            ExpectedCrc(0x80, 0x81, 0x7F, 200, 3, 56, 0, 0)
+        };
+        Assert.That(PgnBuilder.BuildHelloPacket(), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void BuildHelloPacket_CrcIsNotTheAgIoPlaceholder()
+    {
+        Assert.That(PgnBuilder.BuildHelloPacket()[^1], Is.EqualTo(0x82));
     }
 
     // ===== PGN 201 — set subnet =====
@@ -32,30 +78,58 @@ public class ModuleNetworkPgnTests
     [Test]
     public void BuildSubnetChange_MatchesAgIoLayout_WithGivenOctets()
     {
-        // AgIO FormUDP.cs:19 — { 0x80,0x81,0x7F,201,5,201,201, o1,o2,o3, 0x47 }
+        // AgIO FormUDP.cs:19 layout, computed CRC.
         var pgn = PgnBuilder.BuildSubnetChange(192, 168, 5);
-        var expected = new byte[] { 0x80, 0x81, 0x7F, 201, 5, 201, 201, 192, 168, 5, 0x47 };
+        var expected = new byte[]
+        {
+            0x80, 0x81, 0x7F, 201, 5, 201, 201, 192, 168, 5,
+            ExpectedCrc(0x80, 0x81, 0x7F, 201, 5, 201, 201, 192, 168, 5)
+        };
         Assert.That(pgn, Is.EqualTo(expected));
     }
 
     [Test]
-    public void BuildSubnetChange_OnlyOctets7To9Vary()
+    public void BuildSubnetChange_OnlyOctetsAndCrcVary()
     {
         var a = PgnBuilder.BuildSubnetChange(10, 0, 0);
         var b = PgnBuilder.BuildSubnetChange(172, 16, 9);
 
-        // Magic/header/crc bytes are identical; only [7..9] differ.
         Assert.That(a[7], Is.EqualTo(10));
         Assert.That(a[8], Is.EqualTo(0));
         Assert.That(a[9], Is.EqualTo(0));
         Assert.That(b[7], Is.EqualTo(172));
         Assert.That(b[8], Is.EqualTo(16));
         Assert.That(b[9], Is.EqualTo(9));
-        for (int i = 0; i < a.Length; i++)
+
+        // Header/magic bytes are constant; [7..9] carry the octets and the
+        // trailing CRC tracks them, so it varies too.
+        for (int i = 0; i < a.Length - 1; i++)
         {
             if (i is 7 or 8 or 9) continue;
             Assert.That(a[i], Is.EqualTo(b[i]), $"byte {i} should be constant");
         }
+        Assert.That(a[^1], Is.Not.EqualTo(b[^1]), "CRC must track the octets");
+    }
+
+    // ===== Send/validate round-trip =====
+
+    [Test]
+    public void ValidateChecksum_AcceptsEveryModuleNetworkPacketWeSend()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(PgnBuilder.ValidateChecksum(PgnBuilder.BuildScanRequest()), Is.True);
+            Assert.That(PgnBuilder.ValidateChecksum(PgnBuilder.BuildHelloPacket()), Is.True);
+            Assert.That(PgnBuilder.ValidateChecksum(PgnBuilder.BuildSubnetChange(192, 168, 5)), Is.True);
+        });
+    }
+
+    [Test]
+    public void ValidateChecksum_RejectsCorruptedPayload()
+    {
+        var pgn = PgnBuilder.BuildHelloPacket();
+        pgn[5]++;  // payload changed, CRC no longer matches
+        Assert.That(PgnBuilder.ValidateChecksum(pgn), Is.False);
     }
 
     // ===== PGN 203 — scan reply parse =====

--- a/Tests/AgOpenWeb.Services.Tests/PgnChecksumTests.cs
+++ b/Tests/AgOpenWeb.Services.Tests/PgnChecksumTests.cs
@@ -1,0 +1,144 @@
+// AgOpenWeb
+// Copyright (C) 2024-2026 AgOpenWeb Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+using System;
+using System.Collections.Generic;
+using AgOpenWeb.Models;
+using AgOpenWeb.Models.Configuration;
+using AgOpenWeb.Services.AutoSteer;
+
+namespace AgOpenWeb.Services.Tests;
+
+/// <summary>
+/// Every outbound PGN carries a correct trailing checksum, for every builder in
+/// <see cref="PgnBuilder"/> — not just the module-network trio covered by
+/// <c>ModuleNetworkPgnTests</c>.
+/// </summary>
+/// <remarks>
+/// All builders stamp their CRC through the single <c>WithCrc</c> helper, which
+/// derives the checksum span from the buffer length. These tests are the fence
+/// around that: if a packet grows a data byte, or a builder goes back to
+/// hand-writing its own offset and gets it wrong, the round-trip here fails.
+/// The expected sizes are asserted alongside so a silent layout change is
+/// caught rather than being absorbed into a still-valid checksum.
+/// </remarks>
+[TestFixture]
+public class PgnChecksumTests
+{
+    /// <summary>
+    /// Reference CRC, computed independently of the production helper: sum of
+    /// bytes [2 .. len-2], mod 256. Matches PgnMessage.CalculateCRC.
+    /// </summary>
+    private static byte ReferenceCrc(byte[] packet)
+    {
+        int sum = 0;
+        for (int i = 2; i < packet.Length - 1; i++) sum += packet[i];
+        return (byte)(sum & 0xFF);
+    }
+
+    private static VehicleState SampleState() => new()
+    {
+        IsAutoSteerEngaged = true,
+        GpsValid = true,
+        SteerSwitchActive = true,
+        SteerAngle = 7.5,
+        Speed = 9.25,
+        SectionStates = 0xA5C3
+    };
+
+    /// <summary>
+    /// One case per builder. Non-default field values throughout so a checksum
+    /// that ignores part of the payload cannot pass by summing zeros.
+    /// </summary>
+    private static IEnumerable<TestCaseData> AllBuilders()
+    {
+        yield return Case("BuildAutoSteerPgn", 14, () => { var s = SampleState(); return PgnBuilder.BuildAutoSteerPgn(ref s); });
+        yield return Case("BuildMachinePgn", 14, () => { var s = SampleState(); return PgnBuilder.BuildMachinePgn(ref s, uturn: 1, hydLift: 2, tram: 3, geoStop: 1); });
+        yield return Case("BuildSection64Pgn", 16, () => { var s = SampleState(); return PgnBuilder.BuildSection64Pgn(ref s); });
+
+        yield return Case("BuildMachineConfigPgn", 14, () => PgnBuilder.BuildMachineConfigPgn(new MachineConfig
+        {
+            RaiseTime = 3,
+            LowerTime = 5,
+            HydraulicLiftEnabled = true,
+            User1Value = 11,
+            User2Value = 22,
+            User3Value = 33,
+            User4Value = 44
+        }));
+
+        yield return Case("BuildMachinePinsPgn", 30, () => PgnBuilder.BuildMachinePinsPgn(new MachineConfig()));
+
+        yield return Case("BuildSteerSettingsPgn", 14, () => PgnBuilder.BuildSteerSettingsPgn(new AutoSteerConfig
+        {
+            ProportionalGain = 90,
+            MaxPwm = 200,
+            MinPwm = 30,
+            CountsPerDegree = 120,
+            WasOffset = -1234,
+            Ackermann = 150
+        }));
+
+        yield return Case("BuildSteerConfigPgn", 11, () => PgnBuilder.BuildSteerConfigPgn(new AutoSteerConfig
+        {
+            InvertWas = true,
+            DanfossEnabled = true,
+            PressureSensorEnabled = true,
+            MinSteerSpeed = 1.5
+        }));
+
+        yield return Case("BuildScanRequest", 9, PgnBuilder.BuildScanRequest);
+        yield return Case("BuildHelloPacket", 9, PgnBuilder.BuildHelloPacket);
+        yield return Case("BuildSubnetChange", 11, () => PgnBuilder.BuildSubnetChange(172, 16, 9));
+
+        static TestCaseData Case(string name, int expectedLength, Func<byte[]> build) =>
+            new TestCaseData(build, expectedLength).SetName($"{name}_HasValidChecksum");
+    }
+
+    [TestCaseSource(nameof(AllBuilders))]
+    public void EveryBuilder_StampsAChecksumThatValidates(Func<byte[]> build, int expectedLength)
+    {
+        var packet = build();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(packet, Has.Length.EqualTo(expectedLength), "packet length");
+            Assert.That(packet[0], Is.EqualTo(0x80), "header1");
+            Assert.That(packet[1], Is.EqualTo(0x81), "header2");
+            Assert.That(packet[^1], Is.EqualTo(ReferenceCrc(packet)), "trailing CRC");
+            Assert.That(PgnBuilder.ValidateChecksum(packet), Is.True, "round-trips through ValidateChecksum");
+        });
+    }
+
+    /// <summary>
+    /// Corrupting any single payload byte must break validation. This is what
+    /// makes the checksum worth computing at all — a CRC that passes regardless
+    /// of the payload (the old hardcoded 0x47) would survive every other
+    /// assertion in this fixture.
+    /// </summary>
+    [TestCaseSource(nameof(AllBuilders))]
+    public void EveryBuilder_ChecksumTracksThePayload(Func<byte[]> build, int expectedLength)
+    {
+        _ = expectedLength;
+
+        // Snapshot once and mutate copies. The hot-path builders hand back a
+        // reused thread-local buffer, so calling build() again inside the loop
+        // would corrupt the buffer the previous iteration just poked.
+        var pristine = build();
+        var original = (byte[])pristine.Clone();
+
+        // Bytes [2 .. len-2] are covered by the checksum; [0..1] are the header.
+        for (int i = 2; i < original.Length - 1; i++)
+        {
+            var packet = (byte[])original.Clone();
+            packet[i]++;
+            Assert.That(PgnBuilder.ValidateChecksum(packet), Is.False,
+                $"corrupting byte {i} should invalidate the checksum");
+        }
+    }
+}


### PR DESCRIPTION
## Credit

**This builds on @MrPoke21's #72, which found the bug first.** That PR correctly identified that the hello packet was shipping AgIO's stale `0x47` placeholder instead of its real checksum `0x82`, and its diagnosis — "so AgOpenGPS modules can recognize and respond reliably" — is exactly right.

This PR reaches the same wire bytes for the hello and scan packets, then extends the fix to two things #72 doesn't cover. If maintainers prefer to merge #72 first, this rebases onto it cleanly. Either way #72 deserves the credit for spotting it, and it should be closed as superseded rather than stale.

## What AgIO actually does

AgIO ships a stale `0x47` in the trailing CRC slot of its module-network packets and never recomputes it — `UDP.designer.cs:82` rewrites `helloFromAgIO[5]` and leaves the checksum untouched. Modules gate on the header, PGN and magic bytes and ignore the CRC, which is why the placeholder has always been accepted in the field.

We now compute it properly. Firmware that ignores the byte is unaffected; firmware that verifies it now passes rather than relying on luck.

## What this adds over #72

**1. PGN 201 (set subnet) is also fixed.** #72 leaves it on `0x47`. This is the one packet whose checksum genuinely *must* vary, because it depends on the three IP octets in the payload — a hardcoded constant cannot be correct for it under any octet values.

**2. `ValidateChecksum` was broken.** It XOR'd bytes `[0 .. len-2]`, which disagreed with every packet `PgnBuilder` builds — it would have rejected all valid traffic. It now sums `[2 .. len-2]`, matching `CalculateCrc` and `PgnMessage.CalculateCRC`.

It stays diagnostics-only and deliberately unwired from the receive path. Some modules transmit a placeholder CRC of their own, so gating inbound handling on this would drop legitimate traffic and take the link down. That constraint is now written down in the code rather than being folklore.

**3. Computed, not hardcoded.** Every builder routes through a single `WithCrc` helper that derives the checksum offset and span from the buffer length. The seven other builders each hand-wrote `buf[N] = CalculateCrc(buf, 2, N-2)`; all seven were correct, but that is seven places to get wrong when a packet grows a data byte. Hardcoding is what produced this bug in the first place. `WithCrc` stamps in place, so the pooled thread-local buffers the hot-path builders reuse are unaffected.

**4. Tests.** New `PgnChecksumTests` covers all ten builders — expected length, header, CRC against an independently computed reference, and a `ValidateChecksum` round-trip. Plus an assertion that corrupting *any* covered byte invalidates the checksum; without that, a builder regressing to a constant CRC would still satisfy every other assertion in the fixture.

## Why this mattered more than it looked

The vehicle simulator's virtual modules **enforce** the checksum and drop failures silently:

```csharp
if (!PgnProtocol.IsValidPacket(data, data.Length))
    return;                       // no log, no reply
```

So the old hello was being rejected by our own simulator, and the `case PGN_HELLO_FROM_HOST:` arm that calls `SendHello()` in the steer, machine and IMU modules never ran. It didn't surface as an obvious failure because each virtual module also runs an unprompted `HelloLoop` on a 1 s timer, so modules still appeared connected — and every other PGN always computed its CRC correctly, so control traffic worked. The request/response hello path was the only casualty.

## Verification

Services 1051 passed / 2 skipped, Models 146, ViewModels 222. Vehicle simulator builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0133r866nfGcmeM3vabzrYRj
