### PR TITLE
Convert measurements at the web UI's display/input boundary (#65)

### DIFF
--- a/Shared/AgOpenWeb.RemoteServer/Contracts.cs
+++ b/Shared/AgOpenWeb.RemoteServer/Contracts.cs
@@ -497,7 +497,7 @@ public record RecordedPathDto(
 /// recording menu (Outer / Inner N, area, drive-thru / hard flags). The Player.* fields
 /// mirror the live drive-around recording (State.BoundaryRec + the VM toggles). Re-sent on
 /// a fingerprint change. Draw-on-map point drawing is Phase MT and not here.</summary>
-public record BoundaryItemDto(int Index, string BoundaryType, string AreaDisplay, bool DriveThru, bool Hard);
+public record BoundaryItemDto(int Index, string BoundaryType, double AreaHa, bool DriveThru, bool Hard);
 
 public record BoundaryDto(
     IReadOnlyList<BoundaryItemDto> Items,

--- a/Shared/AgOpenWeb.RemoteServer/MapBroadcaster.cs
+++ b/Shared/AgOpenWeb.RemoteServer/MapBroadcaster.cs
@@ -373,7 +373,7 @@ public sealed class MapBroadcaster : IAsyncDisposable
         {
             h = h * 31 + it.Index;
             h = h * 31 + (it.BoundaryType?.GetHashCode() ?? 0);
-            h = h * 31 + (it.AreaDisplay?.GetHashCode() ?? 0);
+            h = h * 31 + it.AreaHa.GetHashCode();
             h = h * 31 + (it.DriveThru ? 1 : 0);
             h = h * 31 + (it.Hard ? 1 : 0);
         }

--- a/Shared/AgOpenWeb.RemoteServer/SceneProjector.cs
+++ b/Shared/AgOpenWeb.RemoteServer/SceneProjector.cs
@@ -751,6 +751,9 @@ public sealed class SceneProjector
         foreach (var n in _configService.GetAvailableToolProfiles()) h = h * 31 + n.GetHashCode();
         h = h * 31 + _config.ActiveVehicleProfileName.GetHashCode();
         h = h * 31 + _config.ActiveToolProfileName.GetHashCode();
+        // The previews are host-rendered strings carrying units, so a metric/imperial
+        // flip changes this frame's content — fold it in or the picker stays stale.
+        h = h * 31 + (_config.IsMetric ? 1 : 2);
         return h * 31 + ConfigFingerprint();
     }
 

--- a/Shared/AgOpenWeb.RemoteServer/WireCodec.cs
+++ b/Shared/AgOpenWeb.RemoteServer/WireCodec.cs
@@ -43,7 +43,7 @@ public static class WireCodec
         {
             w.Write(it.Index);            // i32
             WriteStr(w, it.BoundaryType);
-            WriteStr(w, it.AreaDisplay);
+            w.Write(it.AreaHa);            // f64 (hectares; the client formats ha/ac)
             w.Write((byte)(it.DriveThru ? 1 : 0));
             w.Write((byte)(it.Hard ? 1 : 0));
         }

--- a/Shared/AgOpenWeb.RemoteServer/wwwroot/app.js
+++ b/Shared/AgOpenWeb.RemoteServer/wwwroot/app.js
@@ -96,6 +96,107 @@ let myClientId = null;
 let lastControl = { held: false, holderId: '', holderName: '' };
 let iHoldControl = false;
 
+// ---- Units (issue #65) -------------------------------------------------------
+// Everything the host sends and accepts is METRIC — vehicle/tool geometry in m,
+// section widths / nudge / coverage margin in cm, speeds in km/h, areas in ha.
+// Imperial is a *display/input boundary* conversion only, mirroring the native
+// UnitConversion helper: convert when filling a control or formatting a readout,
+// convert back before sending. Never store or transmit imperial.
+//
+// Markup contract (index.html):
+//   <span class="u" data-unit="m"></span>   → unit label, text filled by applyUnits()
+//   <input data-unit="m" …>                 → value converted on populate + on send
+// The `step` attribute in the HTML is the METRIC step; imperial swaps in impStep
+// (captured once into data-mstep so a unit flip is reversible). impStep matches dec so
+// a written value always lands on the step grid — spinners are hidden by CSS, so step
+// only drives input validation here, and a mismatch would flag a valid entry.
+const UNIT_DEFS = {
+  m:   { metric: 'm',    imp: 'ft',  toImp: v => v * 3.280839895, fromImp: v => v / 3.280839895, dec: 2, impStep: 0.01 },
+  cm:  { metric: 'cm',   imp: 'in',  toImp: v => v / 2.54,        fromImp: v => v * 2.54,        dec: 1, impStep: 0.1 },
+  kmh: { metric: 'km/h', imp: 'mph', toImp: v => v * 0.621371192, fromImp: v => v / 0.621371192, dec: 1, impStep: 0.1 },
+  km:  { metric: 'km',   imp: 'mi',  toImp: v => v * 0.621371192, fromImp: v => v / 0.621371192, dec: 2, impStep: 0.01 },
+  ha:  { metric: 'ha',   imp: 'ac',  toImp: v => v * 2.471053815, fromImp: v => v / 2.471053815, dec: 2, impStep: 0.01 },
+};
+// The status frame is the single source of truth for the unit system; before the
+// first frame arrives we assume metric (matches the host default).
+function isMetric() { return !statusBar || statusBar.isMetric !== false; }
+function unitLabel(u) { const d = UNIT_DEFS[u]; return d ? (isMetric() ? d.metric : d.imp) : (u || ''); }
+function toDisplayUnit(v, u) { const d = UNIT_DEFS[u]; return (!d || isMetric()) ? v : d.toImp(v); }
+function fromDisplayUnit(v, u) { const d = UNIT_DEFS[u]; return (!d || isMetric()) ? v : d.fromImp(v); }
+// Round a display value to the precision that unit deserves (2 dp for m/ft, 1 for
+// cm/in, …). Metric keeps the old 3-dp behaviour so stored values aren't truncated.
+function roundDisplay(v, u) {
+  const d = UNIT_DEFS[u];
+  if (!d || isMetric()) return Math.round(v * 1000) / 1000;
+  const p = Math.pow(10, d.dec);
+  return Math.round(v * p) / p;
+}
+// "12.3 ft" — value (metric in) + unit suffix, formatted for the active system.
+function fmtUnit(v, u, dec) {
+  const d = UNIT_DEFS[u];
+  const n = toDisplayUnit(v, u);
+  return n.toFixed(dec != null ? dec : (d ? d.dec : 1)) + ' ' + unitLabel(u);
+}
+// Fill every `.u` label and re-step every `[data-unit]` input for the active system.
+// Cheap enough to run on any unit flip (a few dozen nodes).
+function applyUnits() {
+  for (const el of document.querySelectorAll('span.u[data-unit]')) el.textContent = unitLabel(el.dataset.unit);
+  for (const inp of document.querySelectorAll('input[data-unit]')) {
+    if (inp.dataset.mstep == null) inp.dataset.mstep = inp.getAttribute('step') || '';
+    const d = UNIT_DEFS[inp.dataset.unit];
+    if (!d) continue;
+    if (isMetric()) { if (inp.dataset.mstep) inp.step = inp.dataset.mstep; }
+    else inp.step = String(d.impStep);
+    // min/max are metric bounds; drop them in imperial rather than convert (the host
+    // clamps anyway) so a valid imperial entry isn't rejected by the browser.
+    if (inp.dataset.mmin == null) inp.dataset.mmin = inp.getAttribute('min') || '';
+    if (isMetric()) { if (inp.dataset.mmin) inp.setAttribute('min', inp.dataset.mmin); }
+    else if (inp.dataset.mmin) inp.removeAttribute('min');
+  }
+}
+// Read a number input as a METRIC value: parse what the user typed (a display value)
+// and convert back. Fields whose metric step is a whole unit are integer-backed
+// host-side (nudge distance, section widths in cm), so round after converting —
+// otherwise 8" → 20.32 cm would fail the host's int parse and silently do nothing.
+function readUnitInput(inp) {
+  const v = parseFloat(inp.value);
+  if (!Number.isFinite(v)) return NaN;
+  const u = inp.dataset.unit;
+  if (!u || isMetric()) return v;
+  const m = fromDisplayUnit(v, u);
+  return Number(inp.dataset.mstep || inp.getAttribute('step')) >= 1 ? Math.round(m) : Math.round(m * 1000) / 1000;
+}
+// Fill a number input from a stored METRIC value, converting for display. A whole-unit
+// metric step means an integer-backed field (cm counts), so metric shows no decimals.
+function writeUnitInput(inp, metricVal) {
+  const u = inp.dataset.unit;
+  if (!u) { inp.value = Math.round(metricVal * 1000) / 1000; return; }
+  if (isMetric() && Number(inp.dataset.mstep || inp.getAttribute('step')) >= 1) { inp.value = Math.round(metricVal); return; }
+  inp.value = roundDisplay(toDisplayUnit(metricVal, u), u);
+}
+// Unit flips arrive on the Status frame (the host persists the setting, then echoes
+// it). Relabel + force every open panel to re-read so values convert immediately.
+let _lastMetric = null;
+function syncUnits() {
+  const m = isMetric();
+  if (m === _lastMetric) return;
+  _lastMetric = m;
+  applyUnits();
+  onUnitsChanged();
+}
+// Everything unit-bearing that isn't redrawn every frame: mark the read-frames dirty so
+// the open panels re-populate through the (now converting) populate path, and drop the
+// wizard's step cache so its hand-built markup is rebuilt with the new labels.
+function onUnitsChanged() {
+  configDirty = true;
+  fieldOpsDirty = true;
+  _wzKey = '';
+  if (document.getElementById('fieldbuilder').classList.contains('open')) { renderFbHeadland(); renderFbTram(); }
+  if (document.getElementById('boundaryplayer').classList.contains('open')) renderBoundaryPlayer();
+}
+applyUnits();   // fill the static labels now (metric default) — the first Status frame corrects it
+
+
 // ---- coverage offscreen (Phase 2): cells painted into a cell-grid canvas,
 //      blitted to world space each frame. Snapshot on connect, deltas after. ----
 let cov = null;        // { cellSize, originE, originN, width, height, canvas, cctx }
@@ -287,7 +388,7 @@ const transport = RemoteTransport.create({
     cov.pending.push({ cells: msg.cells, t: performance.now() });
   },
   onCoverageEdge(polylines) { coverageEdges = polylines; }, // crisp worked-area perimeter (~2 Hz)
-  onStatusBar(s) { statusBar = s; if (typeof applySimBarVisible === 'function') applySimBarVisible(); syncUnsavedCov(); },
+  onStatusBar(s) { statusBar = s; syncUnits(); if (typeof applySimBarVisible === 'function') applySimBarVisible(); syncUnsavedCov(); },
   onConfig(c) { config = c; configDirty = true; applyTheme(c && c.display && c.display.isDayMode); },
   onProfiles(p) { profiles = p; profilesDirty = true; },
   onNtripProfiles(p) { ntripProfiles = p; ntripDirty = true; },
@@ -1685,7 +1786,7 @@ function renderFbHeadland() {
     row.className = 'fb-hlrow' + (s.effective ? '' : ' noeffect') + (i === fbHlSel ? ' sel' : '');
     row.innerHTML = '<span class="fb-dot"></span><span class="fb-hlname"></span><span class="fb-hlmeta"></span>';
     row.querySelector('.fb-hlname').textContent = s.name;
-    row.querySelector('.fb-hlmeta').textContent = s.type + ' · ' + (+s.offset).toFixed(1) + ' m';
+    row.querySelector('.fb-hlmeta').textContent = s.type + ' · ' + fmtUnit(+s.offset, 'm', 1);
     row.addEventListener('pointerdown', ev => { ev.stopPropagation(); fbHlSel = i; renderFbHeadland(); });
     list.appendChild(row);
   });
@@ -1693,20 +1794,20 @@ function renderFbHeadland() {
   if (fbHlSel >= 0 && hs[fbHlSel]) {
     offrow.hidden = false;
     const off = document.getElementById('fb-hl-off');
-    if (document.activeElement !== off) off.value = (+hs[fbHlSel].offset).toFixed(1);
+    if (document.activeElement !== off) writeUnitInput(off, +hs[fbHlSel].offset);
   } else offrow.hidden = true;
 }
 document.getElementById('fb-hl-off').addEventListener('change', e => {
   e.stopPropagation();
   const hs = scene && scene.headlandSegs; if (fbHlSel < 0 || !hs || !hs[fbHlSel]) return;
-  const v = parseFloat(e.target.value);
+  const v = readUnitInput(e.target);   // display → metres before it reaches the host
   if (Number.isFinite(v) && v > 0) transport.send('headland.setOffset|' + hs[fbHlSel].index + ',' + v);
 });
 // Inset = N tool widths (dropdown, mirrors AgOpen's cboxToolWidths) → fills the metre box;
 // editing the metre box directly flips the dropdown to Custom.
 const fbTwSel = document.getElementById('fb-hl-tw');
 const fbNewOff = document.getElementById('fb-hl-newoff');
-function fbApplyTw() { const n = parseInt(fbTwSel.value); if (n > 0) fbNewOff.value = +(n * toolWidthM()).toFixed(1); }
+function fbApplyTw() { const n = parseInt(fbTwSel.value); if (n > 0) writeUnitInput(fbNewOff, n * toolWidthM()); }
 fbTwSel.addEventListener('change', e => { e.stopPropagation(); fbApplyTw(); });
 fbNewOff.addEventListener('input', e => { e.stopPropagation(); fbTwSel.value = '0'; });
 document.getElementById('fb-hl-add').addEventListener('pointerdown', e => {
@@ -1719,7 +1820,7 @@ document.getElementById('fb-hl-addback').addEventListener('pointerdown', e => { 
 for (const b of document.querySelectorAll('#fb-addhl .fb-addbtn'))
   b.addEventListener('pointerdown', e => {
     e.stopPropagation();
-    const off = parseFloat(document.getElementById('fb-hl-newoff').value);
+    const off = readUnitInput(document.getElementById('fb-hl-newoff'));
     const offset = (Number.isFinite(off) && off > 0) ? off : fbDefaultOffset();
     const m = b.dataset.fbhl;
     showFbTab('headland');
@@ -1771,7 +1872,7 @@ function renderFbTram() {
     row.className = 'fb-hlrow' + (s.enabled ? '' : ' noeffect') + (i === fbTramSel ? ' sel' : '');
     row.innerHTML = '<span class="fb-dot"></span><span class="fb-hlname"></span><span class="fb-hlmeta"></span>';
     row.querySelector('.fb-hlname').textContent = s.name;
-    row.querySelector('.fb-hlmeta').textContent = s.width.toFixed(1) + ' m · ' + (s.passCount ? s.passCount + ' pass' : 'all');
+    row.querySelector('.fb-hlmeta').textContent = fmtUnit(s.width, 'm', 1) + ' · ' + (s.passCount ? s.passCount + ' pass' : 'all');
     row.addEventListener('pointerdown', ev => { ev.stopPropagation(); fbTramSel = i; renderFbTram(); });
     list.appendChild(row);
   });
@@ -1799,8 +1900,8 @@ function populateTramEdit() {
   for (const t of (scene.trackList || [])) if (t.type !== 'Path' && t.type !== 'Contour') opts.push(t.name);
   ref.innerHTML = opts.map(o => { const e = document.createElement('option'); e.textContent = o; return e.outerHTML; }).join('');
   ref.value = s.refLabel;
-  const wEl = document.getElementById('fb-tram-w'); if (document.activeElement !== wEl) wEl.value = s.width.toFixed(1);
-  const offEl = document.getElementById('fb-tram-off'); if (document.activeElement !== offEl) offEl.value = s.offset.toFixed(1);
+  const wEl = document.getElementById('fb-tram-w'); if (document.activeElement !== wEl) writeUnitInput(wEl, s.width);
+  const offEl = document.getElementById('fb-tram-off'); if (document.activeElement !== offEl) writeUnitInput(offEl, s.offset);
   const pEl = document.getElementById('fb-tram-passes'); if (document.activeElement !== pEl) pEl.value = s.passCount;
   for (const b of document.querySelectorAll('#fb-tramedit [data-tmode]')) b.classList.toggle('sel', +b.dataset.tmode === s.mode);
   for (const b of document.querySelectorAll('#fb-tramedit [data-tdir]')) b.classList.toggle('sel', +b.dataset.tdir === s.direction);
@@ -1810,8 +1911,8 @@ function populateTramEdit() {
 }
 document.getElementById('fb-tram-en').addEventListener('pointerdown', e => { e.stopPropagation(); const s = curTram(); if (s) tramSet('enabled', s.enabled ? '0' : '1'); });
 document.getElementById('fb-tram-ref').addEventListener('change', e => { e.stopPropagation(); tramSet('ref', e.target.value); });
-document.getElementById('fb-tram-w').addEventListener('change', e => { e.stopPropagation(); const v = parseFloat(e.target.value); if (v > 0) tramSet('width', v); });
-document.getElementById('fb-tram-off').addEventListener('change', e => { e.stopPropagation(); const v = parseFloat(e.target.value); if (Number.isFinite(v)) tramSet('offset', v); });
+document.getElementById('fb-tram-w').addEventListener('change', e => { e.stopPropagation(); const v = readUnitInput(e.target); if (v > 0) tramSet('width', v); });
+document.getElementById('fb-tram-off').addEventListener('change', e => { e.stopPropagation(); const v = readUnitInput(e.target); if (Number.isFinite(v)) tramSet('offset', v); });
 document.getElementById('fb-tram-passes').addEventListener('change', e => { e.stopPropagation(); const v = parseInt(e.target.value); if (Number.isFinite(v)) tramSet('passes', Math.max(0, v)); });
 for (const b of document.querySelectorAll('#fb-tramedit [data-tmode]')) b.addEventListener('pointerdown', e => { e.stopPropagation(); tramSet('mode', b.dataset.tmode); });
 for (const b of document.querySelectorAll('#fb-tramedit [data-tdir]')) b.addEventListener('pointerdown', e => { e.stopPropagation(); tramSet('dir', b.dataset.tdir); });
@@ -1853,7 +1954,7 @@ document.getElementById('bm-driveinner').addEventListener('pointerdown', e => {
 document.getElementById('bm-accept').addEventListener('pointerdown', e => { e.stopPropagation(); transport.send('boundary.accept'); lnCloseAll(); });
 // Boundary player.
 document.getElementById('bp-back').addEventListener('pointerdown', e => { e.stopPropagation(); transport.send('boundary.refresh'); lnOpen('boundarymenu', 'ln-fieldtools', renderBoundaryMenu); });
-document.getElementById('bp-offset').addEventListener('change', e => { e.stopPropagation(); const v = parseFloat(e.target.value); if (Number.isFinite(v)) transport.send('boundary.setOffset|' + v); });
+document.getElementById('bp-offset').addEventListener('change', e => { e.stopPropagation(); const v = readUnitInput(e.target); if (Number.isFinite(v)) transport.send('boundary.setOffset|' + v); });
 document.getElementById('bp-clear').addEventListener('pointerdown', e => { e.stopPropagation(); transport.send('boundary.clear'); });
 document.getElementById('bp-section').addEventListener('pointerdown', e => { e.stopPropagation(); transport.send('boundary.toggleSectionControl'); });
 document.getElementById('bp-undo').addEventListener('pointerdown', e => { e.stopPropagation(); transport.send('boundary.undo'); });
@@ -1867,8 +1968,8 @@ for (const b of document.querySelectorAll('#offsetfix .of-btn'))
   b.addEventListener('pointerdown', e => { e.stopPropagation(); transport.send(b.dataset.cmd); });
 // Manual Easting/Northing entry → absolute set (offset.set|E,N).
 function sendOffsetSet() {
-  const ns = parseFloat(document.getElementById('of-ns-in').value);
-  const ew = parseFloat(document.getElementById('of-ew-in').value);
+  const ns = readUnitInput(document.getElementById('of-ns-in'));
+  const ew = readUnitInput(document.getElementById('of-ew-in'));
   if (Number.isFinite(ns) && Number.isFinite(ew)) transport.send('offset.set|' + ew + ',' + ns);
 }
 for (const id of ['of-ns-in', 'of-ew-in'])
@@ -1938,8 +2039,11 @@ function fmtRo(v, fmt) {
   }
 }
 function wireCfgControls(panel) {
+  // A data-unit input holds a DISPLAY value; readUnitInput converts it back to the
+  // stored metric unit (and rounds whole-unit fields). Without data-unit it is the
+  // old raw parseFloat, so untagged controls are unaffected.
   for (const inp of panel.querySelectorAll('.cfg-num'))
-    inp.addEventListener('change', () => { const v = parseFloat(inp.value); if (Number.isFinite(v)) cfgSend(inp.dataset.key, v); });
+    inp.addEventListener('change', () => { const v = readUnitInput(inp); if (Number.isFinite(v)) cfgSend(inp.dataset.key, v); });
   for (const b of panel.querySelectorAll('.cfg-tgl'))
     b.addEventListener('pointerdown', e => { e.stopPropagation(); cfgSend(b.dataset.key, b.classList.contains('active') ? '0' : '1'); });
   for (const b of panel.querySelectorAll('.cfg-typebtn'))
@@ -1963,7 +2067,7 @@ function populateCfgControls(panel, force) {
   for (const inp of panel.querySelectorAll('.cfg-num')) {
     if (!force && document.activeElement === inp) continue;
     const val = cfgGet(inp.dataset.key);
-    if (typeof val === 'number') inp.value = Math.round(val * 1000) / 1000;
+    if (typeof val === 'number') writeUnitInput(inp, val);
   }
   for (const b of panel.querySelectorAll('.cfg-tgl')) {
     const on = !!cfgGet(b.dataset.key);
@@ -2049,12 +2153,13 @@ document.getElementById('tc-save').addEventListener('pointerdown', e => { e.stop
 const PIN_FUNCS = ['None', 'Sec1', 'Sec2', 'Sec3', 'Sec4', 'Sec5', 'Sec6', 'Sec7', 'Sec8', 'Sec9', 'Sec10',
   'Sec11', 'Sec12', 'Sec13', 'Sec14', 'Sec15', 'Sec16', 'HydUp', 'HydDown', 'TramLeft', 'TramRight', 'GeoStop'];
 const _tcBuilt = { sw: -1, ze: -1, sc: false, pins: false };
-function tcDynInput(parent, idx, label, type, onChange) {
+function tcDynInput(parent, idx, label, type, onChange, unit) {
   const c = document.createElement('div'); c.className = 'tc-cell';
   const sp = document.createElement('span'); sp.textContent = label;
   const inp = document.createElement(type === 'pin' ? 'select' : 'input');
   if (type === 'pin') PIN_FUNCS.forEach((l, fi) => { const o = document.createElement('option'); o.value = fi; o.textContent = l; inp.appendChild(o); });
   else { inp.type = type; if (type === 'number') inp.step = '1'; }
+  if (unit) inp.dataset.unit = unit;   // stored-unit tag → applyUnits() re-steps it
   inp.dataset.idx = idx;
   inp.addEventListener('change', () => onChange(inp));
   c.appendChild(sp); c.appendChild(inp); parent.appendChild(c);
@@ -2082,10 +2187,11 @@ function populateToolCfg(force) {
   const nSec = Math.max(1, Math.min(64, t.numSections)); // ToolConfig.MaxSections — backend supports 64
   if (_tcBuilt.sw !== nSec) {
     const g = document.getElementById('tc-sectionwidths'); g.innerHTML = '';
-    for (let i = 0; i < nSec; i++) tcDynInput(g, i, 'S' + (i + 1), 'number', inp => { const v = parseFloat(inp.value); if (Number.isFinite(v)) cfgSend('tool.sectionWidth', i + ',' + v); });
+    for (let i = 0; i < nSec; i++) tcDynInput(g, i, 'S' + (i + 1), 'number', inp => { const v = readUnitInput(inp); if (Number.isFinite(v)) cfgSend('tool.sectionWidth', i + ',' + v); }, 'cm');
     _tcBuilt.sw = nSec;
+    applyUnits();   // freshly built boxes need the active unit's step
   }
-  for (const inp of document.querySelectorAll('#tc-sectionwidths input')) if (force || document.activeElement !== inp) inp.value = Math.round(t.sectionWidths[+inp.dataset.idx]);
+  for (const inp of document.querySelectorAll('#tc-sectionwidths input')) if (force || document.activeElement !== inp) writeUnitInput(inp, t.sectionWidths[+inp.dataset.idx]);
   const nZone = Math.max(1, Math.min(8, t.zones));
   if (_tcBuilt.ze !== nZone) {
     const g = document.getElementById('tc-zoneends'); g.innerHTML = '';
@@ -2106,7 +2212,7 @@ function populateToolCfg(force) {
     _tcBuilt.pins = true;
   }
   for (const sel of document.querySelectorAll('#tc-pins select')) if (document.activeElement !== sel) sel.value = config.machine.pinAssignments[+sel.dataset.idx];
-  document.getElementById('tc-totalwidth').textContent = 'Total width: ' + (t.totalWidth || 0).toFixed(2) + ' m';
+  document.getElementById('tc-totalwidth').textContent = 'Total width: ' + fmtUnit(t.totalWidth || 0, 'm');
 }
 
 // ---- AutoSteer config panel (Phase 9) — full native 9-tab surface + live Test Mode ----
@@ -2426,8 +2532,8 @@ function renderFieldsAndJobs() {
     row.innerHTML = '<span class="fj-fname"></span><span class="fj-fnum"></span><span class="fj-fnum"></span>';
     row.querySelector('.fj-fname').textContent = f.name;
     const nums = row.querySelectorAll('.fj-fnum');
-    nums[0].textContent = f.hasDistance ? f.distanceKm.toFixed(1) : '—';
-    nums[1].textContent = f.areaHa.toFixed(1);
+    nums[0].textContent = f.hasDistance ? toDisplayUnit(f.distanceKm, 'km').toFixed(1) : '—';
+    nums[1].textContent = toDisplayUnit(f.areaHa, 'ha').toFixed(1);
     row.addEventListener('pointerdown', ev => { ev.stopPropagation(); fjSelField = f.name; fjSelJob = null; renderFieldsAndJobs(); });
     fl.appendChild(row);
   }
@@ -2641,7 +2747,7 @@ function renderAgDownload() {
     const row = document.createElement('div'); row.className = 'fj-jrow' + (f.id === agdSel ? ' sel' : '');
     row.innerHTML = '<div class="fj-jtop"><span class="fj-jname"></span><span class="fj-jwt"></span></div>';
     row.querySelector('.fj-jname').textContent = f.name;
-    row.querySelector('.fj-jwt').textContent = f.areaHa.toFixed(2) + ' ha';
+    row.querySelector('.fj-jwt').textContent = fmtUnit(f.areaHa, 'ha');
     row.addEventListener('pointerdown', ev => { ev.stopPropagation(); agdSel = f.id; renderAgDownload(); });
     list.appendChild(row);
   }
@@ -2675,7 +2781,7 @@ document.getElementById('fm-bugreport').addEventListener('pointerdown', e => { e
 
 // App Settings: units (status) + device toggles (config.display) + app directories (appInfo).
 function renderAppSettings() {
-  const metric = !!(statusBar && statusBar.isMetric);
+  const metric = isMetric();
   document.getElementById('as-metric').classList.toggle('active', metric);
   document.getElementById('as-imperial').classList.toggle('active', !metric);
   const d = config && config.display;
@@ -2793,7 +2899,9 @@ document.getElementById('br-submit').addEventListener('pointerdown', e => {
 // (wizard.action). Editable values display from the Config frame. ----
 const wzOverlay = document.getElementById('wizard-overlay');
 const wzContent = document.getElementById('wz-content');
-let _wzKey = ''; // stepKind|index of the currently-built content (rebuild on change)
+// stepKind|index of the currently-built content (rebuild on change — and on a unit
+// flip, which onUnitsChanged forces by clearing this).
+let _wzKey = '';
 function openSteerWizard() { _wzKey = ''; wizard = null; transport.send('wizard.open'); wzOverlay.classList.add('open'); }
 function wzClose(send) { if (send) transport.send('wizard.cancel'); wzOverlay.classList.remove('open'); wizard = null; _wzKey = ''; }
 document.getElementById('wz-cancel').addEventListener('pointerdown', e => { e.stopPropagation(); wzClose(true); });
@@ -2817,15 +2925,22 @@ wzContent.addEventListener('pointerdown', e => {
 });
 wzContent.addEventListener('change', e => {
   const inp = e.target.closest('[data-cfgnum]'); if (!inp) return;
-  const v = parseFloat(inp.value); if (Number.isFinite(v)) cfgSend(inp.dataset.cfgnum, v);
+  const v = readUnitInput(inp); if (Number.isFinite(v)) cfgSend(inp.dataset.cfgnum, v);
 });
 // Per-step content. Editable values read from the Config frame; live values get ids
 // (data-live) refreshed each frame. esc() guards interpolated strings.
 function esc(s) { return String(s == null ? '' : s).replace(/[&<>"]/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c])); }
 function wzVal(key, dflt) { const v = cfgGet(key); return typeof v === 'number' ? v : (dflt || 0); }
+// `unit` is the STORED unit key ('m', 'kmh', …) or a plain suffix ('deg', '') that
+// carries no conversion. Unit-keyed fields render the display value and tag the input
+// so the change handler converts back; applyUnits() re-steps them on a unit flip.
 function wzNum(label, sub, key, step, unit) {
+  const known = UNIT_DEFS[unit];
+  const val = known ? roundDisplay(toDisplayUnit(wzVal(key), unit), unit) : wzVal(key);
+  const istep = known && !isMetric() ? known.impStep : (step || '0.01');
   return '<div class="wz-fld"><label>' + esc(label) + '</label><div class="sub">' + esc(sub || '') + '</div>' +
-    '<input class="wz-num" data-cfgnum="' + key + '" type="number" step="' + (step || '0.01') + '" value="' + wzVal(key) + '"><span class="wz-unit">' + esc(unit || '') + '</span></div>';
+    '<input class="wz-num" data-cfgnum="' + key + '"' + (known ? ' data-unit="' + unit + '" data-mstep="' + (step || '0.01') + '"' : '') +
+    ' type="number" step="' + istep + '" value="' + val + '"><span class="wz-unit">' + esc(known ? unitLabel(unit) : (unit || '')) + '</span></div>';
 }
 function wzSeg(label, sub, key, opts) { // opts: [[text,val],...]
   return '<div class="wz-row"><div class="lbl">' + esc(label) + (sub ? '<div class="sub">' + esc(sub) + '</div>' : '') + '</div><div class="wz-seg">' +
@@ -2904,8 +3019,8 @@ function buildWizardContent(w) {
         wzNum('Side Hill Compensation', 'Degrees per degree of roll (0-1.0)', 'autosteer.sideHillCompensation', '0.01', '') + '</div>';
     case 'speed':
       return head + '<div class="wz-rows">' +
-        wzNum('Min Steer Speed', 'Engage above this speed', 'autosteer.minSteerSpeed', '0.1', 'km/h') +
-        wzNum('Max Steer Speed', 'Safety cutoff speed', 'autosteer.maxSteerSpeed', '0.1', 'km/h') +
+        wzNum('Min Steer Speed', 'Engage above this speed', 'autosteer.minSteerSpeed', '0.1', 'kmh') +
+        wzNum('Max Steer Speed', 'Safety cutoff speed', 'autosteer.maxSteerSpeed', '0.1', 'kmh') +
         wzTgl('Turn Sensor', 'Steering wheel encoder', 'autosteer.turnSensorEnabled') +
         wzTgl('Pressure Sensor', 'Hydraulic stall detection', 'autosteer.pressureSensorEnabled') +
         wzTgl('Current Sensor', 'Motor current obstruction detection', 'autosteer.currentSensorEnabled') +
@@ -2923,7 +3038,7 @@ function renderWizard() {
   asSetText('wz-step', 'Step ' + (w.stepIndex + 1) + ' of ' + w.totalSteps);
   document.getElementById('wz-progressbar').style.width = (w.totalSteps ? (w.stepIndex + 1) / w.totalSteps * 100 : 0) + '%';
   asSetText('wz-was', (w.statusWas || 0).toFixed(1) + '°'); asSetText('wz-roll', (w.statusRoll || 0).toFixed(1) + '°');
-  asSetText('wz-gps', w.statusGps || '—'); asSetText('wz-speed', (w.statusSpeed || 0).toFixed(1) + ' km/h'); asSetText('wz-pwm', w.statusPwm | 0);
+  asSetText('wz-gps', w.statusGps || '—'); asSetText('wz-speed', fmtUnit(w.statusSpeed || 0, 'kmh', 1)); asSetText('wz-pwm', w.statusPwm | 0);
   const next = document.getElementById('wz-next');
   next.textContent = w.isLast ? 'Finish' : 'Next';
   next.classList.toggle('disabled', !(w.isLast || w.canNext));
@@ -2944,7 +3059,7 @@ function renderWizard() {
   const live = (k, v) => { for (const el of wzContent.querySelectorAll('[data-live="' + k + '"]')) el.textContent = v; };
   live('angle', (w.liveAngle || 0).toFixed(1) + '°'); live('roll', (w.liveRoll || 0).toFixed(2) + '°');
   live('error', (w.liveError || 0).toFixed(1)); live('phase', w.testPhase || ''); live('result', w.testResult || '');
-  live('fix', w.fixLabel || (w.statusGps || '—')); live('speed', (w.statusSpeed || 0).toFixed(1) + ' km/h');
+  live('fix', w.fixLabel || (w.statusGps || '—')); live('speed', fmtUnit(w.statusSpeed || 0, 'kmh', 1));
   live('rollzero', wzVal('roll.rollZero').toFixed(2)); live('wasoffset', wzVal('autosteer.wasOffset') | 0);
   // Roll gauge (roll-calibration step): rotate the bar by the live roll, like the map.
   const rb = document.getElementById('wz-roll-bar');
@@ -3443,13 +3558,13 @@ function renderPose() {
     speed: s.b.speed,
   };
 }
-// Cross-track error as "12 cm R" (R = right of line, +xte). Centimetres so the
-// magnitude reads at a glance; the lightbar carries the live feel.
+// Cross-track error as "12 cm R" / "5 in R" (R = right of line, +xte). Centimetres
+// (inches in imperial) so the magnitude reads at a glance; the lightbar carries the
+// live feel.
 function xteText(xte) {
   if (xte == null) return '—';
-  const cm = Math.abs(xte) * 100;
   const side = xte > 0.005 ? 'R' : xte < -0.005 ? 'L' : '·';
-  return `${cm.toFixed(0)} cm ${side}`;
+  return `${fmtUnit(Math.abs(xte) * 100, 'cm', 0)} ${side}`;
 }
 
 // Lightbar readout text → DOM overlay (the LED strip itself is drawn by lightbarSk).
@@ -3473,7 +3588,7 @@ function updateLightbarText() {
     // 1-based pass label (human counting): the reference AB line is "Pass 1", one over is
     // "Pass 2", etc. — magnitude only (the arrow already shows which way to steer).
     const pass = (tick.op ? tick.op.passNumber : 0) | 0;
-    lbEl.textContent = `${arrow} ${(Math.abs(xte) * 100).toFixed(0)} cm   Pass ${Math.abs(pass) + 1}`;
+    lbEl.textContent = `${arrow} ${fmtUnit(Math.abs(xte) * 100, 'cm', 0)}   Pass ${Math.abs(pass) + 1}`;
   }
   lbEl.style.display = 'block';
 }
@@ -3490,8 +3605,7 @@ function updateHeadlandHud() {
   // instruction pill + toolbar. body.maptap is set by startMapTap for the duration of the flow.
   const creating = document.body.classList.contains('maptap');
   if (!on || creating || d == null || d < 0) { hlHud.style.display = 'none'; return; }
-  const metric = !statusBar || statusBar.isMetric;
-  hlHud.textContent = metric ? d.toFixed(1) + ' m' : (d * 3.28084).toFixed(0) + ' ft';
+  hlHud.textContent = isMetric() ? fmtUnit(d, 'm', 1) : fmtUnit(d, 'm', 0);
   hlHud.classList.toggle('warn', !!(tick && tick.headlandWarn));
   hlHud.style.display = 'block';
 }
@@ -3547,13 +3661,8 @@ function moduleAggColor(s) {
   return pres === conf ? '#22c55e' : '#f59e0b';
 }
 // Area/rate formatting — matches MainViewModel.FormatArea / WorkRateDisplay.
-function fmtArea(m2, metric) {
-  const ha = m2 * 0.0001;
-  return metric ? ha.toFixed(2) + ' ha' : (ha * 2.47105).toFixed(2) + ' ac';
-}
-function fmtRate(haPerHr, metric) {
-  return metric ? haPerHr.toFixed(1) + ' ha/hr' : (haPerHr * 2.47105).toFixed(1) + ' ac/hr';
-}
+function fmtArea(m2) { return fmtUnit(m2 * 0.0001, 'ha'); }
+function fmtRate(haPerHr) { return fmtUnit(haPerHr, 'ha', 1) + '/hr'; }
 // Workable area (m²) from the Scene the client already has: headland polygon if
 // present, else the outer boundary (shoelace) — matches WorkableAreaSqM.
 function shoelace(pts) {
@@ -3588,7 +3697,7 @@ function rotatingLineText() {
     const workable = workableAreaSqM(), worked = s.workedAreaSqM || 0;
     const leftPct = workable > 0 ? ((workable - worked) * 100 / workable) : 100;
     const haPerHr = (lastTick ? lastTick.speed : 0) * 3600 * toolWidthM() / 10000;
-    return 'Done ' + fmtArea(worked, s.isMetric) + '  Left ' + leftPct.toFixed(0) + '%  Rate ' + fmtRate(haPerHr, s.isMetric);
+    return 'Done ' + fmtArea(worked) + '  Left ' + leftPct.toFixed(0) + '%  Rate ' + fmtRate(haPerHr);
   }
   const name = tick && tick.activeTrackName; // AB-line page
   if (!name) return 'No AB Line';
@@ -3661,8 +3770,8 @@ function renderStatusBar() {
   SB.rot.textContent = rotatingLineText();
   // Speed from the live tick (m/s), formatted per the host's unit preference.
   const mps = lastTick ? lastTick.speed : 0;
-  SB.speed.textContent = (mps * (s.isMetric ? 3.6 : 2.236936)).toFixed(1);
-  SB.unit.textContent = s.isMetric ? 'km/h' : 'mph';
+  SB.speed.textContent = toDisplayUnit(mps * 3.6, 'kmh').toFixed(1);
+  SB.unit.textContent = unitLabel('kmh');
   // Modules: aggregate dot + per-module popup rows.
   SB.modAgg.style.background = moduleAggColor(s);
   const dot = (el, ok) => { el.style.background = ok ? '#22c55e' : '#6b7280'; };
@@ -3725,7 +3834,7 @@ function renderSimBar() {
   }
   // Speed readout: apply 10× then format per units (mirrors SimulatorSpeedDisplay).
   const eff = (s.simSpeedKph || 0) * (s.sim10x ? 10 : 1);
-  SIM.speedVal.textContent = s.isMetric ? eff.toFixed(1) + ' kph' : (eff * 0.621371).toFixed(1) + ' mph';
+  SIM.speedVal.textContent = fmtUnit(eff, 'kmh', 1);
   // GPS (teleport) only while sim disabled — matches the native IsEnabled binding.
   SIM.gps.disabled = !!s.simEnabled;
   SIM.gps.style.opacity = s.simEnabled ? '0.4' : '1';
@@ -3836,9 +3945,7 @@ function renderUTurnIndicator() {
   const show = !!(scene && scene.hasField && op && op.youturn && op.distToTrigger > 0);
   UTI.root.hidden = !show;
   if (!show) return;
-  const metric = !statusBar || statusBar.isMetric;
-  UTI.dist.textContent = metric ? op.distToTrigger.toFixed(0) + ' m'
-                                : (op.distToTrigger * 3.28084).toFixed(0) + ' ft';
+  UTI.dist.textContent = fmtUnit(op.distToTrigger, 'm', 0);
   UTI.arrow.classList.toggle('left', !!op.turnLeft);
   const style = (config && config.uturn && config.uturn.style) || 0;
   UTI.typePath.setAttribute('d', UTURN_GLYPH[style] || UTURN_GLYPH[0]);
@@ -3918,7 +4025,7 @@ function pushChartData(t) {
     steer: [t.chartSetSteer, t.chartActualSteer, t.chartPwm],
     // HeadingError mirrors the native quirk (ComputeHeadingError == set steer angle).
     heading: [t.chartSetSteer, t.chartImuHeading, hdgDeg],
-    xte: [t.crossTrackError],
+    xte: [toDisplayUnit(t.crossTrackError, 'm')],   // plot in the active length unit
   };
   const trim = now - CHART_WINDOW - 2;
   for (const key in CHARTS) {
@@ -4098,8 +4205,8 @@ function renderOffsetFix() {
   if (!document.getElementById('offsetfix').classList.contains('open')) return;
   if (!statusBar) return;
   const ns = document.getElementById('of-ns-in'), ew = document.getElementById('of-ew-in');
-  if (document.activeElement !== ns) ns.value = (statusBar.driftNorthing || 0).toFixed(3);
-  if (document.activeElement !== ew) ew.value = (statusBar.driftEasting || 0).toFixed(3);
+  if (document.activeElement !== ns) writeUnitInput(ns, statusBar.driftNorthing || 0);
+  if (document.activeElement !== ew) writeUnitInput(ew, statusBar.driftEasting || 0);
 }
 
 // Import Tracks: list the other fields that have saved tracks; tap one to copy its
@@ -4204,12 +4311,12 @@ function renderBoundaryMenu() {
 function renderBoundaryPlayer() {
   const b = boundary; if (!b) return;
   const off = document.getElementById('bp-offset');
-  if (document.activeElement !== off) off.value = (b.offsetCm || 0).toFixed(0);
+  if (document.activeElement !== off) writeUnitInput(off, b.offsetCm || 0);
   document.getElementById('bp-section').classList.toggle('on', b.sectionControlOn);
   document.getElementById('bp-lrimg').src = b.drawRightSide ? '/icons/BoundaryRight.png' : '/icons/BoundaryLeft.png';
   document.getElementById('bp-atimg').src = b.drawAtPivot ? '/icons/BoundaryRecordPivot.png' : '/icons/BoundaryRecordTool.png';
   document.getElementById('bp-points').textContent = b.pointCount;
-  document.getElementById('bp-area').textContent = (b.areaHa || 0).toFixed(2) + ' Ha';
+  document.getElementById('bp-area').textContent = fmtUnit(b.areaHa || 0, 'ha');
   document.getElementById('bp-recimg').src = b.isRecording ? '/icons/boundaryPause.png' : '/icons/BoundaryRecord.png';
 }
 

--- a/Shared/AgOpenWeb.RemoteServer/wwwroot/app.js
+++ b/Shared/AgOpenWeb.RemoteServer/wwwroot/app.js
@@ -192,6 +192,7 @@ function onUnitsChanged() {
   fieldOpsDirty = true;
   _wzKey = '';
   if (document.getElementById('fieldbuilder').classList.contains('open')) { renderFbHeadland(); renderFbTram(); }
+  if (document.getElementById('boundarymenu').classList.contains('open')) renderBoundaryMenu();
   if (document.getElementById('boundaryplayer').classList.contains('open')) renderBoundaryPlayer();
 }
 applyUnits();   // fill the static labels now (metric default) — the first Status frame corrects it
@@ -4293,7 +4294,7 @@ function renderBoundaryMenu() {
       + '<span class="bm-flag ' + (it.driveThru ? 'on' : 'off') + '" data-flag="driveThru"></span>'
       + '<span class="bm-flag ' + (it.hard ? 'on' : 'off') + '" data-flag="hard"></span>';
     row.querySelector('.bm-name').textContent = it.boundaryType;
-    row.querySelector('.bm-area').textContent = it.areaDisplay;
+    row.querySelector('.bm-area').textContent = fmtUnit(it.areaHa, 'ha');
     row.querySelector('[data-flag="driveThru"]').textContent = it.driveThru ? 'Yes' : '--';
     row.querySelector('[data-flag="hard"]').textContent = it.hard ? 'Hard' : 'Soft';
     row.addEventListener('pointerdown', ev => { ev.stopPropagation(); transport.send('boundary.select|' + it.index); });

--- a/Shared/AgOpenWeb.RemoteServer/wwwroot/index.html
+++ b/Shared/AgOpenWeb.RemoteServer/wwwroot/index.html
@@ -1299,16 +1299,16 @@
             <img id="vc-img-hitch" class="vc-diag" alt="">
             <div class="vc-fieldcol">
               <label>Coupling type</label><select class="cfg-sel" data-key="vehicle.hitchType"></select>
-              <label>Hitch length (m)</label><input class="cfg-num" data-key="vehicle.hitchLength" type="number" step="0.01" inputmode="decimal">
+              <label>Hitch length (<span class="u" data-unit="m"></span>)</label><input class="cfg-num" data-unit="m" data-key="vehicle.hitchLength" type="number" step="0.01" inputmode="decimal">
             </div>
           </div>
           <div class="vc-diagrow">
             <img id="vc-img-wheelbase" class="vc-diag" alt="">
-            <div class="vc-fieldcol"><label>Wheelbase (m)</label><input class="cfg-num" data-key="vehicle.wheelbase" type="number" step="0.01" inputmode="decimal"></div>
+            <div class="vc-fieldcol"><label>Wheelbase (<span class="u" data-unit="m"></span>)</label><input class="cfg-num" data-unit="m" data-key="vehicle.wheelbase" type="number" step="0.01" inputmode="decimal"></div>
           </div>
           <div class="vc-diagrow">
             <img id="vc-img-track" class="vc-diag" alt="">
-            <div class="vc-fieldcol"><label>Track width (m)</label><input class="cfg-num" data-key="vehicle.trackWidth" type="number" step="0.01" inputmode="decimal"></div>
+            <div class="vc-fieldcol"><label>Track width (<span class="u" data-unit="m"></span>)</label><input class="cfg-num" data-unit="m" data-key="vehicle.trackWidth" type="number" step="0.01" inputmode="decimal"></div>
           </div>
         </div>
         <div>
@@ -1316,14 +1316,14 @@
           <div class="vc-diagrow">
             <img id="vc-img-antside" class="vc-diag" alt="">
             <div class="vc-fieldcol">
-              <label>Antenna pivot (m)</label><input class="cfg-num" data-key="vehicle.antennaPivot" type="number" step="0.01" inputmode="decimal">
-              <label>Antenna height (m)</label><input class="cfg-num" data-key="vehicle.antennaHeight" type="number" step="0.01" inputmode="decimal">
+              <label>Antenna pivot (<span class="u" data-unit="m"></span>)</label><input class="cfg-num" data-unit="m" data-key="vehicle.antennaPivot" type="number" step="0.01" inputmode="decimal">
+              <label>Antenna height (<span class="u" data-unit="m"></span>)</label><input class="cfg-num" data-unit="m" data-key="vehicle.antennaHeight" type="number" step="0.01" inputmode="decimal">
             </div>
           </div>
           <div class="vc-diagrow">
             <img id="vc-img-antoffset" class="vc-diag" alt="">
             <div class="vc-fieldcol">
-              <label>Antenna offset (m)</label><input class="cfg-num" data-key="vehicle.antennaOffset" type="number" step="0.01" inputmode="decimal">
+              <label>Antenna offset (<span class="u" data-unit="m"></span>)</label><input class="cfg-num" data-unit="m" data-key="vehicle.antennaOffset" type="number" step="0.01" inputmode="decimal">
               <div class="ln-seg">
                 <button class="cfg-act" data-key="vehicle.antennaSide" data-val="left">Left</button>
                 <button class="cfg-act" data-key="vehicle.antennaSide" data-val="center">Center</button>
@@ -1341,16 +1341,16 @@
           <div class="cfg-grid">
             <label>Dual GPS</label><button class="cfg-tgl" data-key="gps.isDualGps">Off</button>
             <label>Heading offset (°)</label><input class="cfg-num" data-key="gps.dualHeadingOffset" type="number" step="0.1" inputmode="decimal">
-            <label>Reverse dist (m)</label><input class="cfg-num" data-key="gps.dualReverseDistance" type="number" step="0.1" inputmode="decimal">
+            <label>Reverse dist (<span class="u" data-unit="m"></span>)</label><input class="cfg-num" data-unit="m" data-key="gps.dualReverseDistance" type="number" step="0.1" inputmode="decimal">
             <label>Auto dual fix</label><button class="cfg-tgl" data-key="gps.autoDualFix">Off</button>
-            <label>Switch speed</label><input class="cfg-num" data-key="gps.dualSwitchSpeed" type="number" step="0.1" inputmode="decimal">
+            <label>Switch speed (<span class="u" data-unit="kmh"></span>)</label><input class="cfg-num" data-unit="kmh" data-key="gps.dualSwitchSpeed" type="number" step="0.1" inputmode="decimal">
           </div>
         </div>
         <div>
           <div class="cfg-label">Single antenna</div>
           <div class="cfg-grid">
-            <label>Min GPS step (m)</label><input class="cfg-num" data-key="gps.minGpsStep" type="number" step="0.01" inputmode="decimal">
-            <label>Fix-to-fix dist (m)</label><input class="cfg-num" data-key="gps.fixToFixDistance" type="number" step="0.01" inputmode="decimal">
+            <label>Min GPS step (<span class="u" data-unit="m"></span>)</label><input class="cfg-num" data-unit="m" data-key="gps.minGpsStep" type="number" step="0.01" inputmode="decimal">
+            <label>Fix-to-fix dist (<span class="u" data-unit="m"></span>)</label><input class="cfg-num" data-unit="m" data-key="gps.fixToFixDistance" type="number" step="0.01" inputmode="decimal">
             <label>Reverse detection</label><button class="cfg-tgl" data-key="gps.reverseDetection">Off</button>
           </div>
           <div class="cfg-grid" style="margin-top:6px"><label>Heading fusion <span id="vc-hfw">—</span></label><input class="cfg-slider" data-key="gps.headingFusionWeight" type="range" min="0" max="1" step="0.05"></div>
@@ -1410,10 +1410,10 @@
           <img id="tc-img-hitch" class="vc-diag" alt="">
           <div class="vc-fieldcol">
             <label>Coupling type</label><select class="cfg-sel" data-key="tool.hitchType"></select>
-            <label data-show="rigid">Working center (m)</label><input class="cfg-num" data-key="tool.hitchLength" data-show="rigid" type="number" step="0.01">
-            <label data-show="trailtbt">Trailing hitch (m)</label><input class="cfg-num" data-key="tool.trailingHitchLength" data-show="trailtbt" type="number" step="0.01">
-            <label data-show="tbt">Tank trailing hitch (m)</label><input class="cfg-num" data-key="tool.tankTrailingHitchLength" data-show="tbt" type="number" step="0.01">
-            <label>Implement length (m)</label><input class="cfg-num" data-key="tool.length" type="number" step="0.01">
+            <label data-show="rigid">Working center (<span class="u" data-unit="m"></span>)</label><input class="cfg-num" data-unit="m" data-key="tool.hitchLength" data-show="rigid" type="number" step="0.01">
+            <label data-show="trailtbt">Trailing hitch (<span class="u" data-unit="m"></span>)</label><input class="cfg-num" data-unit="m" data-key="tool.trailingHitchLength" data-show="trailtbt" type="number" step="0.01">
+            <label data-show="tbt">Tank trailing hitch (<span class="u" data-unit="m"></span>)</label><input class="cfg-num" data-unit="m" data-key="tool.tankTrailingHitchLength" data-show="tbt" type="number" step="0.01">
+            <label>Implement length (<span class="u" data-unit="m"></span>)</label><input class="cfg-num" data-unit="m" data-key="tool.length" type="number" step="0.01">
           </div>
         </div>
       </div>
@@ -1426,17 +1426,17 @@
       </div>
       <div id="tcs-offset" class="cfg-body" data-strip="tc-sub" hidden>
         <div class="vc-diagrow"><img src="/icons/ToolOffsetPositiveRight.png" class="vc-diag" alt=""><div class="vc-fieldcol">
-          <label>Tool offset (m)</label><input class="cfg-num" data-key="tool.offset" type="number" step="0.01">
+          <label>Tool offset (<span class="u" data-unit="m"></span>)</label><input class="cfg-num" data-unit="m" data-key="tool.offset" type="number" step="0.01">
           <label>Direction</label><div class="ln-seg"><button class="cfg-act" data-key="tool.offsetSide" data-val="left">Left</button><button class="cfg-act" data-key="tool.offsetSide" data-val="center">Zero</button><button class="cfg-act" data-key="tool.offsetSide" data-val="right">Right</button></div>
         </div></div>
         <div class="vc-diagrow"><img src="/icons/ToolOverlap.png" class="vc-diag" alt=""><div class="vc-fieldcol">
-          <label>Overlap / gap (m)</label><input class="cfg-num" data-key="tool.overlap" type="number" step="0.01">
+          <label>Overlap / gap (<span class="u" data-unit="m"></span>)</label><input class="cfg-num" data-unit="m" data-key="tool.overlap" type="number" step="0.01">
           <label>Mode</label><div class="ln-seg"><button class="cfg-act" data-key="tool.overlapSide" data-val="overlap">Overlap</button><button class="cfg-act" data-key="tool.overlapSide" data-val="zero">Zero</button><button class="cfg-act" data-key="tool.overlapSide" data-val="gap">Gap</button></div>
         </div></div>
       </div>
       <div id="tcs-pivot" class="cfg-body" data-strip="tc-sub" hidden>
         <div class="vc-diagrow"><img src="/icons/ToolHitchPivotOffsetPos.png" class="vc-diag" alt=""><div class="vc-fieldcol">
-          <label>Pivot distance (m)</label><input class="cfg-num" data-key="tool.trailingToolToPivotLength" type="number" step="0.01">
+          <label>Pivot distance (<span class="u" data-unit="m"></span>)</label><input class="cfg-num" data-unit="m" data-key="tool.trailingToolToPivotLength" type="number" step="0.01">
           <label>Direction</label><div class="ln-seg"><button class="cfg-act" data-key="tool.pivotSide" data-val="behind">Behind</button><button class="cfg-act" data-key="tool.pivotSide" data-val="zero">Zero</button><button class="cfg-act" data-key="tool.pivotSide" data-val="ahead">Ahead</button></div>
         </div></div>
         <div class="cfg-note" data-show="notrailtbt">Pivot settings apply only to Trailing and TBT tools.</div>
@@ -1451,10 +1451,10 @@
             </div>
             <div class="cfg-grid">
               <label>Number of sections</label><input class="cfg-num" data-key="tool.numSections" type="number" step="1" min="1" max="64">
-              <label>Default width (cm)</label><input class="cfg-num" data-key="tool.defaultSectionWidth" type="number" step="1">
+              <label>Default width (<span class="u" data-unit="cm"></span>)</label><input class="cfg-num" data-unit="cm" data-key="tool.defaultSectionWidth" type="number" step="1">
             </div>
             <div data-show="individual">
-              <div class="cfg-label">Section widths (cm)</div>
+              <div class="cfg-label">Section widths (<span class="u" data-unit="cm"></span>)</div>
               <div id="tc-sectionwidths" class="tc-dyngrid"></div>
             </div>
             <div data-show="zones">
@@ -1475,8 +1475,8 @@
               <label>Off outside boundary</label><button class="cfg-tgl" data-key="tool.isSectionOffWhenOut">Off</button>
               <label>Off in headland</label><button class="cfg-tgl" data-key="tool.isHeadlandSectionControl">Off</button>
               <label>Min coverage (%)</label><input class="cfg-num" data-key="tool.minCoverage" type="number" step="1">
-              <label>Slow speed cutoff (km/h)</label><input class="cfg-num" data-key="tool.slowSpeedCutoff" type="number" step="0.1">
-              <label>Coverage margin (cm)</label><input class="cfg-num" data-key="tool.coverageMargin" type="number" step="1">
+              <label>Slow speed cutoff (<span class="u" data-unit="kmh"></span>)</label><input class="cfg-num" data-unit="kmh" data-key="tool.slowSpeedCutoff" type="number" step="0.1">
+              <label>Coverage margin (<span class="u" data-unit="cm"></span>)</label><input class="cfg-num" data-unit="cm" data-key="tool.coverageMargin" type="number" step="1">
             </div>
           </div>
         </div>
@@ -1507,10 +1507,10 @@
         <button class="cfg-typebtn" data-key="uturn.style" data-val="1">K-turn</button>
       </div>
       <div class="cfg-diaggrid">
-        <div class="vc-diagrow"><img src="/icons/ConU_UturnLength.png" class="vc-diag" alt=""><div class="vc-fieldcol"><label>Extension (m)</label><input class="cfg-num" data-key="uturn.extension" type="number" step="0.1"></div></div>
+        <div class="vc-diagrow"><img src="/icons/ConU_UturnLength.png" class="vc-diag" alt=""><div class="vc-fieldcol"><label>Extension (<span class="u" data-unit="m"></span>)</label><input class="cfg-num" data-unit="m" data-key="uturn.extension" type="number" step="0.1"></div></div>
         <div class="vc-diagrow"><img src="/icons/ConU_UturnSmooth.png" class="vc-diag" alt=""><div class="vc-fieldcol"><label>Smoothing</label><input class="cfg-num" data-key="uturn.smoothing" type="number" step="1"></div></div>
-        <div class="vc-diagrow"><img src="/icons/ConU_UturnRadius.png" class="vc-diag" alt=""><div class="vc-fieldcol"><label>Radius (m)</label><input class="cfg-num" data-key="uturn.radius" type="number" step="0.1"></div></div>
-        <div class="vc-diagrow"><img src="/icons/ConU_UturnDistance.png" class="vc-diag" alt=""><div class="vc-fieldcol"><label>Distance from bndry (m)</label><input class="cfg-num" data-key="uturn.distanceFromBoundary" type="number" step="0.1"></div></div>
+        <div class="vc-diagrow"><img src="/icons/ConU_UturnRadius.png" class="vc-diag" alt=""><div class="vc-fieldcol"><label>Radius (<span class="u" data-unit="m"></span>)</label><input class="cfg-num" data-unit="m" data-key="uturn.radius" type="number" step="0.1"></div></div>
+        <div class="vc-diagrow"><img src="/icons/ConU_UturnDistance.png" class="vc-diag" alt=""><div class="vc-fieldcol"><label>Distance from bndry (<span class="u" data-unit="m"></span>)</label><input class="cfg-num" data-unit="m" data-key="uturn.distanceFromBoundary" type="number" step="0.1"></div></div>
       </div>
     </div>
     <!-- ===== MACHINE ===== -->
@@ -1698,9 +1698,9 @@
         <div id="as-speed" class="cfg-body" data-strip="as-right" hidden>
           <div class="as-card as-togcard"><img src="/icons/con_VehicleFunctionSpeedLimit.png" alt=""><label>Manual turns</label><button class="cfg-tgl" data-key="autosteer.manualTurnsEnabled">Off</button></div>
           <div class="as-card"><div class="cfg-grid">
-            <label>Manual turns speed (km/h)</label><input class="cfg-num" data-key="autosteer.manualTurnsSpeed" type="number" step="0.1">
-            <label>Min steer speed (km/h)</label><input class="cfg-num" data-key="autosteer.minSteerSpeed" type="number" step="0.1">
-            <label>Max steer speed (km/h)</label><input class="cfg-num" data-key="autosteer.maxSteerSpeed" type="number" step="0.1">
+            <label>Manual turns speed (<span class="u" data-unit="kmh"></span>)</label><input class="cfg-num" data-unit="kmh" data-key="autosteer.manualTurnsSpeed" type="number" step="0.1">
+            <label>Min steer speed (<span class="u" data-unit="kmh"></span>)</label><input class="cfg-num" data-unit="kmh" data-key="autosteer.minSteerSpeed" type="number" step="0.1">
+            <label>Max steer speed (<span class="u" data-unit="kmh"></span>)</label><input class="cfg-num" data-unit="kmh" data-key="autosteer.maxSteerSpeed" type="number" step="0.1">
           </div></div>
         </div>
 
@@ -1709,7 +1709,7 @@
           <div class="as-caphdr">Line Width (px)</div>
           <div class="as-valrow"><img class="as-dia" src="/icons/ConV_LineWith.png" alt=""><span class="as-valbox cfg-ro" data-for="autosteer.lineWidth" data-fmt="f0">—</span><input class="cfg-slider" data-key="autosteer.lineWidth" data-fmt="f0" type="range" min="1" max="8" step="1"></div>
           <div class="as-card"><div class="cfg-grid">
-            <label>Nudge distance (cm)</label><input class="cfg-num" data-key="autosteer.nudgeDistance" type="number" step="1">
+            <label>Nudge distance (<span class="u" data-unit="cm"></span>)</label><input class="cfg-num" data-unit="cm" data-key="autosteer.nudgeDistance" type="number" step="1">
             <label>Next guidance (s)</label><input class="cfg-num" data-key="autosteer.nextGuidanceTime" type="number" step="0.1">
             <label>cm per pixel</label><input class="cfg-num" data-key="autosteer.cmPerPixel" type="number" step="1">
           </div></div>
@@ -1851,7 +1851,7 @@
     <div class="fj-cols">
       <div class="fj-col">
         <div class="cfg-label">Fields</div>
-        <div class="fj-fhead"><span>Name</span><span>Dist (km)</span><span>Area (ha)</span></div>
+        <div class="fj-fhead"><span>Name</span><span>Dist (<span class="u" data-unit="km"></span>)</span><span>Area (<span class="u" data-unit="ha"></span>)</span></div>
         <div id="fj-fieldlist" class="fj-list"></div>
         <div class="fj-btnrow">
           <button class="cfg-act" id="fj-openonly">Open Field Only</button>
@@ -2102,7 +2102,7 @@
         <button id="fb-hl-deleteall" class="fb-act fb-del">Delete All</button>
       </div>
       <div id="fb-hl-offrow" class="fb-offrow" hidden>
-        <label>Offset</label><input id="fb-hl-off" class="cfg-num" type="number" step="0.5" min="0.5"><span>m</span>
+        <label>Offset</label><input id="fb-hl-off" class="cfg-num" data-unit="m" type="number" step="0.5" min="0.5"><span class="u" data-unit="m"></span>
       </div>
     </div>
     <!-- Add Headland sub-view (replaces the tab content) -->
@@ -2119,7 +2119,7 @@
           <option value="6">6 tool widths</option>
           <option value="0">Custom</option>
         </select>
-        <input id="fb-hl-newoff" class="cfg-num" type="number" step="0.5" min="0.5"><span>m</span>
+        <input id="fb-hl-newoff" class="cfg-num" data-unit="m" type="number" step="0.5" min="0.5"><span class="u" data-unit="m"></span>
       </div>
       <div class="fb-sublbl">Draw on Map — one line per edge; where they cross encloses the headland</div>
       <div class="fb-addrow">
@@ -2145,13 +2145,13 @@
       <div class="fb-subhdr"><button id="fb-tram-back" class="fb-act">← Back</button><span id="fb-tram-title">Edit System</span></div>
       <div class="fb-offrow"><label>Enabled</label><button id="fb-tram-en" class="cfg-tgl">On</button></div>
       <div class="fb-offrow"><label>Reference</label><select id="fb-tram-ref" class="cfg-isel"></select></div>
-      <div class="fb-offrow"><label>Tram width</label><input id="fb-tram-w" class="cfg-num" type="number" step="0.5" min="0.5"><span>m</span></div>
+      <div class="fb-offrow"><label>Tram width</label><input id="fb-tram-w" class="cfg-num" data-unit="m" type="number" step="0.5" min="0.5"><span class="u" data-unit="m"></span></div>
       <div class="fb-sublbl">Mode</div>
       <div class="fb-addrow">
         <button class="fb-addbtn" data-tmode="0"><img src="/icons/TramLines.png" alt=""><span>Wheel Track</span></button>
         <button class="fb-addbtn" data-tmode="1"><img src="/icons/TramOuter.png" alt=""><span>Edge</span></button>
       </div>
-      <div id="fb-tram-offrow" class="fb-offrow"><label>Offset</label><input id="fb-tram-off" class="cfg-num" type="number" step="0.5"><span>m</span></div>
+      <div id="fb-tram-offrow" class="fb-offrow"><label>Offset</label><input id="fb-tram-off" class="cfg-num" data-unit="m" type="number" step="0.5"><span class="u" data-unit="m"></span></div>
       <div id="fb-tram-dirlbl" class="fb-sublbl">Direction</div>
       <div id="fb-tram-dir" class="fb-addrow">
         <button class="fb-addbtn" data-tdir="1"><img src="/icons/SnapLeft.png" alt=""><span>Left</span></button>
@@ -2189,8 +2189,8 @@
       <button class="of-btn of-ns" id="of-s" data-cmd="offset.south">S</button>
     </div>
     <div class="of-manual">
-      <div class="of-fld"><label>N / S (m)</label><input id="of-ns-in" class="of-input" type="number" step="0.001"></div>
-      <div class="of-fld"><label>E / W (m)</label><input id="of-ew-in" class="of-input" type="number" step="0.001"></div>
+      <div class="of-fld"><label>N / S (<span class="u" data-unit="m"></span>)</label><input id="of-ns-in" class="of-input" data-unit="m" type="number" step="0.001"></div>
+      <div class="of-fld"><label>E / W (<span class="u" data-unit="m"></span>)</label><input id="of-ew-in" class="of-input" data-unit="m" type="number" step="0.001"></div>
     </div>
     <div class="of-hint">1 cm per click</div>
   </div>
@@ -2252,7 +2252,7 @@
     <div class="ln-hdr"><button class="ln-x" id="bp-back" title="Back">←</button><span class="ln-hdr-title">Stop Record Pause Boundary</span><button class="ln-x ln-closex" title="Close">✕</button></div>
     <div class="bp-offrow">
       <span class="bp-offlbl">Recording Offset</span>
-      <input id="bp-offset" class="bp-offin" type="number" step="1" value="100"><span class="bp-offunit">cm</span>
+      <input id="bp-offset" class="bp-offin" data-unit="cm" type="number" step="1" value="100"><span class="bp-offunit u" data-unit="cm"></span>
     </div>
     <div class="bp-grid">
       <button id="bp-clear" class="bp-btn" title="Clear all points"><img src="/icons/Trash.png" alt=""></button>

--- a/Shared/AgOpenWeb.RemoteServer/wwwroot/transport.js
+++ b/Shared/AgOpenWeb.RemoteServer/wwwroot/transport.js
@@ -219,7 +219,7 @@ window.RemoteTransport = {
         }
         case TYPE.BOUNDARY: {
           const ic = i32(); const items = new Array(ic);
-          for (let k = 0; k < ic; k++) items[k] = { index: i32(), boundaryType: str(), areaDisplay: str(), driveThru: !!u8(), hard: !!u8() };
+          for (let k = 0; k < ic; k++) items[k] = { index: i32(), boundaryType: str(), areaHa: f64(), driveThru: !!u8(), hard: !!u8() };
           const selectedIndex = i32(), playerVisible = !!u8(), isRecording = !!u8(), isPaused = !!u8();
           const pointCount = i32(), areaHa = f64(), offsetCm = f64();
           const drawRightSide = !!u8(), drawAtPivot = !!u8(), sectionControlOn = !!u8();

--- a/Shared/AgOpenWeb.RemoteWiring/RemoteServerWiring.cs
+++ b/Shared/AgOpenWeb.RemoteWiring/RemoteServerWiring.cs
@@ -713,7 +713,7 @@ public static partial class RemoteServerWiring
                         var items = new System.Collections.Generic.List<AgOpenWeb.RemoteServer.BoundaryItemDto>();
                         foreach (var it in vm.BoundaryItems)
                             items.Add(new AgOpenWeb.RemoteServer.BoundaryItemDto(
-                                it.Index, it.BoundaryType, it.AreaDisplay, it.IsDriveThrough, it.IsHard));
+                                it.Index, it.BoundaryType, it.AreaHectares, it.IsDriveThrough, it.IsHard));
                         var bpts = new System.Collections.Generic.List<double>(brs.RecordedPoints.Count * 2);
                         foreach (var p in brs.RecordedPoints) { bpts.Add(p.Easting); bpts.Add(p.Northing); }
                         return new AgOpenWeb.RemoteServer.BoundaryDto(

--- a/Shared/AgOpenWeb.Services/ConfigurationService.cs
+++ b/Shared/AgOpenWeb.Services/ConfigurationService.cs
@@ -19,6 +19,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
 using AgOpenWeb.Models;
+using AgOpenWeb.Models.Base;
 using AgOpenWeb.Models.Configuration;
 using AgOpenWeb.Services.Interfaces;
 using AgOpenWeb.Services.Profile;
@@ -68,39 +69,49 @@ public class ConfigurationService(
     {
         // Active profile already lives in the store — no disk read.
         if (string.Equals(name, Store.ActiveVehicleProfileName, StringComparison.OrdinalIgnoreCase))
-            return FormatVehicle(Store);
+            return FormatVehicle(Store, Store.IsMetric);
         // Non-active: read its file into a throwaway store (side-effect-free —
         // quarantineOnFailure:false so previewing a damaged profile doesn't move it).
+        // Units come from the device store, not `temp` — IsMetric is a device setting
+        // and the throwaway store carries only the profile's own values.
         var temp = new ConfigurationStore();
         bool ok = VehicleProfileJsonService.Load(ProfilesDirectory, name, temp, out _, out _, quarantineOnFailure: false)
                || ProfileJsonServiceV1.Load(ProfilesDirectory, name, temp);
-        return ok ? FormatVehicle(temp) : $"Vehicle profile '{name}'\n(file not found / unreadable)";
+        return ok ? FormatVehicle(temp, Store.IsMetric) : $"Vehicle profile '{name}'\n(file not found / unreadable)";
     }
 
     public string GetToolProfilePreview(string name)
     {
         if (string.Equals(name, Store.ActiveToolProfileName, StringComparison.OrdinalIgnoreCase))
-            return FormatTool(Store);
+            return FormatTool(Store, Store.IsMetric);
         var temp = new ConfigurationStore();
         bool ok = ToolProfileJsonService.Load(ToolsDirectory, name, temp, out _, out _, quarantineOnFailure: false)
                || ProfileJsonServiceV1.Load(ProfilesDirectory, name, temp);
-        return ok ? FormatTool(temp) : $"Tool profile '{name}'\n(file not found / unreadable)";
+        return ok ? FormatTool(temp, Store.IsMetric) : $"Tool profile '{name}'\n(file not found / unreadable)";
     }
 
-    private static string FormatVehicle(ConfigurationStore store)
+    /// <summary>
+    /// A stored length (metres) rendered for display: "2.50 m" or "8.20 ft". These
+    /// previews are the one place the host renders a measurement into a string the
+    /// client prints verbatim, so the unit conversion has to happen here.
+    /// </summary>
+    private static string Len(double meters, bool isMetric) =>
+        isMetric ? $"{meters:F2} m" : $"{UnitConversion.MetersToFeet(meters):F2} ft";
+
+    private static string FormatVehicle(ConfigurationStore store, bool isMetric)
     {
         var v = store.Vehicle;
         return
             $"Type: {v.Type}\n" +
-            $"Wheelbase: {v.Wheelbase:F2} m\n" +
-            $"Track width: {v.TrackWidth:F2} m\n" +
-            $"Antenna height: {v.AntennaHeight:F2} m\n" +
-            $"Antenna pivot: {v.AntennaPivot:F2} m\n" +
-            $"Antenna offset: {v.AntennaOffset:F2} m\n" +
+            $"Wheelbase: {Len(v.Wheelbase, isMetric)}\n" +
+            $"Track width: {Len(v.TrackWidth, isMetric)}\n" +
+            $"Antenna height: {Len(v.AntennaHeight, isMetric)}\n" +
+            $"Antenna pivot: {Len(v.AntennaPivot, isMetric)}\n" +
+            $"Antenna offset: {Len(v.AntennaOffset, isMetric)}\n" +
             $"Max steer angle: {v.MaxSteerAngle:F1}°";
     }
 
-    private static string FormatTool(ConfigurationStore store)
+    private static string FormatTool(ConfigurationStore store, bool isMetric)
     {
         var t = store.Tool;
         string attach = t.IsToolFrontFixed ? "Front fixed"
@@ -108,9 +119,9 @@ public class ConfigurationService(
                       : t.IsToolTrailing ? "Trailing"
                       : "—";
         return
-            $"Width: {t.Width:F2} m\n" +
-            $"Overlap: {t.Overlap:F2} m\n" +
-            $"Offset: {t.Offset:F2} m\n" +
+            $"Width: {Len(t.Width, isMetric)}\n" +
+            $"Overlap: {Len(t.Overlap, isMetric)}\n" +
+            $"Offset: {Len(t.Offset, isMetric)}\n" +
             $"Sections: {store.NumSections}\n" +
             $"Min coverage: {t.MinCoverage}%\n" +
             $"Attach: {attach}";

--- a/Shared/AgOpenWeb.ViewModels/MainViewModel.cs
+++ b/Shared/AgOpenWeb.ViewModels/MainViewModel.cs
@@ -4223,7 +4223,7 @@ public partial class MainViewModel : ObservableObject
             {
                 Index = index++,
                 BoundaryType = "Outer",
-                AreaAcres = boundary.OuterBoundary.AreaAcres,
+                AreaHectares = boundary.OuterBoundary.AreaHectares,
                 IsDriveThrough = boundary.OuterBoundary.IsDriveThrough,
                 IsHard = boundary.OuterBoundary.IsHard
             });
@@ -4239,7 +4239,7 @@ public partial class MainViewModel : ObservableObject
                 {
                     Index = index++,
                     BoundaryType = $"Inner {i + 1}",
-                    AreaAcres = inner.AreaAcres,
+                    AreaHectares = inner.AreaHectares,
                     IsDriveThrough = inner.IsDriveThrough,
                     IsHard = inner.IsHard
                 });
@@ -6021,10 +6021,11 @@ public class BoundaryListItem
 {
     public int Index { get; set; }
     public string BoundaryType { get; set; } = string.Empty;
-    public double AreaAcres { get; set; }
+    /// <summary>Area in hectares — the storage unit. Formatting (ha vs ac) belongs to
+    /// the display boundary, so this stays a number all the way to the client.</summary>
+    public double AreaHectares { get; set; }
     public bool IsDriveThrough { get; set; }
     public bool IsHard { get; set; }
-    public string AreaDisplay => $"{AreaAcres:F2} Ac";
     public string DriveThruDisplay => IsDriveThrough ? "Yes" : "--";
     public string HardDisplay => IsHard ? "Hard" : "Soft";
 }


### PR DESCRIPTION
Fixes #65.

## The problem

Selecting **Imperial** under File → App Settings → Units flipped the button and persisted the preference, but most of the web UI kept showing metres and centimetres. `config.set|units:imperial` correctly set `ConfigurationStore.IsMetric` host-side; the display layer just never used it.

Two causes, addressed in two commits.

---

## Commit 1 — the display/input boundary (`app.js` + `index.html`)

`wwwroot/index.html` hard-coded `(m)` / `(cm)` / `(km/h)` in the labels, `populateCfgControls()` put stored metric values straight into the inputs, and `wireCfgControls()` sent typed values back without converting.

Models keep storing metric. Conversion happens only at the display/input boundary — the same contract as the native `UnitConversion` helper.

**Markup contract** (`index.html`, 37 sites):

```html
<span class="u" data-unit="m"></span>   <!-- unit label, text filled by applyUnits() -->
<input data-unit="m" …>                 <!-- value converted on populate + on send -->
```

The HTML `step`/`min` stay metric and are stashed into `data-mstep`/`data-mmin`, so a unit flip is reversible in both directions.

**`app.js`** gains a `UNIT_DEFS` table (m↔ft, cm↔in, km/h↔mph, km↔mi, ha↔ac) plus `unitLabel` / `toDisplayUnit` / `fromDisplayUnit` / `fmtUnit` / `readUnitInput` / `writeUnitInput` / `applyUnits`. `syncUnits()` rides the Status frame and, on a change, relabels and marks the read-frames dirty so open panels re-populate immediately.

Fields whose metric step is a whole unit (nudge distance, section widths, coverage margin) are int-backed host-side, so they round after converting: `8 in` → `20 cm`, not `20.32`, which the host's `int.TryParse` would have dropped silently.

Covered: Vehicle geometry · GPS distances and switch speed · Tool lengths/offsets, section + default widths, coverage margin, slow-speed cutoff, total width · U-turn · AutoSteer speed limits and nudge · Steer Wizard fields and live readouts · Field Builder headland + tram · boundary player offset and area · Offset Fix · field and AgShare lists · lightbar and XTE readouts · XTE chart.

---

## Commit 2 — three measurements the JS fix could not reach

A follow-up sweep found three values rendered into strings **host-side** and printed verbatim by `app.js`, so commit 1 could not touch them.

**Boundary list area** was the worst of the three: `BoundaryListItem.AreaDisplay` was hardcoded `$"{AreaAcres:F2} Ac"` and ignored `IsMetric` entirely — the boundary menu showed acres even in metric mode. Fixed by sending the number instead of a string: `BoundaryListItem` now stores `AreaHectares`, `BoundaryItemDto` carries `AreaHa` as `f64`, and the client formats it with `fmtUnit` like the sibling `BoundaryDto.AreaHa` it sits next to. Wire codec and fingerprint follow; client and server ship as one artifact, so there's no protocol-version concern.

**Vehicle and tool profile previews** (`ConfigurationService.FormatVehicle` / `FormatTool`) hardcoded `" m"` with no imperial branch. These stay host-rendered — they're labelled free text, not editable values, so a structured DTO would only move the labels into JS — but they now take the device `IsMetric` and render via `UnitConversion.MetersToFeet`. The flag comes from `Store`, not from the throwaway `ConfigurationStore` used to preview a non-active profile: `IsMetric` is a device setting and the temp store holds only the profile's own values.

`ProfilesFingerprint()` folds in `IsMetric` so a unit flip actually re-sends the frame — without it the picker preview stayed stale until some other config changed. `renderBoundaryMenu` joins `onUnitsChanged` for the same reason.

---

## Verification

Built the Desktop head, ran it headless, and drove the real page through Chrome's DevTools Protocol — including a generated field, boundary and profile pair for the commit-2 paths.

| Stored (metric) | Imperial | Metric |
|---|---|---|
| wheelbase 2.5 m | `8.2` ft, step `0.01` | `2.5`, step `0.01` |
| nudge 20 cm | `7.9` in | `20` |
| section width 100 cm | `39.4` in | `100` |
| slow-speed cutoff 0.5 km/h | `0.3` mph | `0.5` |
| XTE 0.123 m | `5 in R` | `12 cm R` |
| 12345 m² | `3.05 ac` | `1.23 ha` |
| boundary 4.0536 ha | `10.02 ac` | `4.05 ha` |
| vehicle preview | `Wheelbase: 8.20 ft` | `Wheelbase: 2.50 m` |
| tool preview | `Width: 19.69 ft` | `Width: 6.00 m` |

Round-trip on input: typing `10` ft sends `3.048`; typing `8` in sends `20`. A live metric → imperial → metric flip restored every label, value, `step` and `min` exactly, and refreshed the host-rendered previews. No console errors on load; test suite green (1419 passed, 0 failed); the environment's unit preference and profile/field directories were left as found.

## Platforms

The iOS and Android heads need **no changes**. There's a single `wwwroot` in the repo, embedded as a resource by `AgOpenWeb.RemoteServer` (`csproj:33`); both heads `ProjectReference` that project and pick it up on rebuild. Neither contains any measurement formatting, and neither has native UI beyond a splash `TextBlock`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0132tf3qziiQTJv8AiJmwvVR
