### PR TITLE
Fix: KML/ISO-XML import list always empty on headless installs

### DIFF
--- a/Shared/AgOpenWeb.RemoteServer/SceneProjector.cs
+++ b/Shared/AgOpenWeb.RemoteServer/SceneProjector.cs
@@ -453,7 +453,7 @@ public sealed class SceneProjector
         return new FieldOpsDto(fields, jobs, suggestions, iso, kml, _fields.ActiveField?.Name ?? "");
     }
 
-    // ISO-XML (subdirs with TASKDATA.xml) + KML/KMZ files under ~/Documents/AgOpenWeb/Import.
+    // ISO-XML (subdirs with TASKDATA.xml) + KML/KMZ files under <data root>/Import.
     // Mirrors MainViewModel.PopulateAvailableIsoXmlFiles / PopulateAvailableKmlFiles.
     private static (System.Collections.Generic.List<string> iso, System.Collections.Generic.List<string> kml) ScanImportFolder()
     {
@@ -461,9 +461,11 @@ public sealed class SceneProjector
         var kml = new System.Collections.Generic.List<string>();
         try
         {
-            var docs = System.Environment.GetFolderPath(System.Environment.SpecialFolder.MyDocuments);
-            if (string.IsNullOrEmpty(docs)) docs = System.Environment.GetFolderPath(System.Environment.SpecialFolder.Personal);
-            var importDir = System.IO.Path.Combine(docs, "AgOpenWeb", "Import");
+            // Resolve the Import folder from the shared AgOpenWeb data root (honors
+            // AGOPENWEB_DATA), same as Fields/Tools/Vehicles/NtripProfiles. Using
+            // MyDocuments directly diverged from the data root on headless installs,
+            // so the scanned folder never matched where files actually live.
+            var importDir = System.IO.Path.Combine(AppDataRoot.Documents, "Import");
             if (!System.IO.Directory.Exists(importDir)) return (iso, kml);
             foreach (var dir in System.IO.Directory.GetDirectories(importDir))
                 if (System.IO.File.Exists(System.IO.Path.Combine(dir, "TASKDATA.xml")))

--- a/Shared/AgOpenWeb.ViewModels/MainViewModel.cs
+++ b/Shared/AgOpenWeb.ViewModels/MainViewModel.cs
@@ -4513,13 +4513,11 @@ public partial class MainViewModel : ObservableObject
     {
         AvailableKmlFiles.Clear();
 
-        var documentsPath = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
-        if (string.IsNullOrEmpty(documentsPath))
-        {
-            documentsPath = Environment.GetFolderPath(Environment.SpecialFolder.Personal);
-        }
-
-        var importDir = Path.Combine(documentsPath, "AgOpenWeb", "Import");
+        // Import folder lives under the shared AgOpenWeb data root (honors
+        // AGOPENWEB_DATA on the headless appliance), same as Fields/Tools/Vehicles —
+        // NOT MyDocuments, which diverges from the data root on headless installs and
+        // left the KML/ISO import list empty even when files were present.
+        var importDir = Path.Combine(AppDataRoot.Documents, "Import");
 
         if (!Directory.Exists(importDir))
         {
@@ -4783,13 +4781,11 @@ public partial class MainViewModel : ObservableObject
     {
         AvailableIsoXmlFiles.Clear();
 
-        var documentsPath = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
-        if (string.IsNullOrEmpty(documentsPath))
-        {
-            documentsPath = Environment.GetFolderPath(Environment.SpecialFolder.Personal);
-        }
-
-        var importDir = Path.Combine(documentsPath, "AgOpenWeb", "Import");
+        // Import folder lives under the shared AgOpenWeb data root (honors
+        // AGOPENWEB_DATA on the headless appliance), same as Fields/Tools/Vehicles —
+        // NOT MyDocuments, which diverges from the data root on headless installs and
+        // left the KML/ISO import list empty even when files were present.
+        var importDir = Path.Combine(AppDataRoot.Documents, "Import");
 
         if (!Directory.Exists(importDir))
         {


### PR DESCRIPTION
## What changed

Resolve the KML/ISO-XML **Import** folder from `AppDataRoot.Documents` (which honors the `AGOPENWEB_DATA` env var) instead of `Environment.SpecialFolder.MyDocuments`, matching how Fields, Tools, Vehicles and NtripProfiles already resolve their directories.

**Why:** on a headless/appliance install `AGOPENWEB_DATA` points the data root outside the program dir (e.g. `/home/agopenweb`), while `MyDocuments` resolves to `~/Documents`. The import scanners hardcoded `MyDocuments`, so they looked in `~/Documents/AgOpenWeb/Import` while every other data dir -- and the files users actually drop in -- live under `<AGOPENWEB_DATA>/AgOpenWeb/Import`. Result: the **From KML** / ISO-XML import dropdowns were always empty on headless hosts even with valid files present.

Three call sites, all now using `AppDataRoot.Documents`:
- `SceneProjector.ScanImportFolder` (remote/web projection -- the headless path)
- `MainViewModel.PopulateAvailableKmlFiles`
- `MainViewModel.PopulateAvailableIsoXmlFiles`

No behavior change on Desktop/mobile: with `AGOPENWEB_DATA` unset, `AppDataRoot.Documents` = `<MyDocuments>/AgOpenWeb`, so the folder stays `<MyDocuments>/AgOpenWeb/Import` as before.

## Related issue

No existing issue -- happy to open one / claim a board card if preferred. Found on a real headless (systemd) deployment of v26.6.74.

## Pre-submit checklist

- [x] `dotnet build` succeeds with no errors (built `AgOpenWeb.ViewModels` and `AgOpenWeb.RemoteServer` with `-p:DesktopOnly=true`, .NET 10.0.401)
- [ ] `dotnet test` -- not run; change is a mechanical reuse of the existing `AppDataRoot` resolver, no new logic
- [x] Tested on: headless Linux appliance (`AGOPENWEB_DATA=/home/agopenweb`). With the fix, `fieldOps.kmlFiles` and the From KML dropdown populate from `<data root>/AgOpenWeb/Import`.

## Notes / possible follow-up (not in this PR)

- `FieldOpsFingerprint()` intentionally excludes import-folder contents, so files added while a client is connected only appear after a reconnect or a field/job change. Left as-is.
- Two `FieldsDirectory` fallbacks in `MainViewModel.Commands.Fields.cs` still hardcode `MyDocuments`; harmless today (only hit when the setting is empty) but could be aligned to `AppDataRoot.Documents` in a follow-up.
