### PR TITLE
Fix: profile previews honor AppSettings units (imperial)

### DIFF
--- a/Shared/AgOpenWeb.Services/ConfigurationService.cs
+++ b/Shared/AgOpenWeb.Services/ConfigurationService.cs
@@ -69,26 +69,32 @@ public class ConfigurationService(
     {
         // Active profile already lives in the store — no disk read.
         if (string.Equals(name, Store.ActiveVehicleProfileName, StringComparison.OrdinalIgnoreCase))
-            return FormatVehicle(Store, Store.IsMetric);
+            return FormatVehicle(Store, PreviewIsMetric);
         // Non-active: read its file into a throwaway store (side-effect-free —
         // quarantineOnFailure:false so previewing a damaged profile doesn't move it).
-        // Units come from the device store, not `temp` — IsMetric is a device setting
-        // and the throwaway store carries only the profile's own values.
+        // Units are a display concern — take the authoritative AppSettings value, not
+        // `temp` (which carries only the profile's own values).
         var temp = new ConfigurationStore();
         bool ok = VehicleProfileJsonService.Load(ProfilesDirectory, name, temp, out _, out _, quarantineOnFailure: false)
                || ProfileJsonServiceV1.Load(ProfilesDirectory, name, temp);
-        return ok ? FormatVehicle(temp, Store.IsMetric) : $"Vehicle profile '{name}'\n(file not found / unreadable)";
+        return ok ? FormatVehicle(temp, PreviewIsMetric) : $"Vehicle profile '{name}'\n(file not found / unreadable)";
     }
 
     public string GetToolProfilePreview(string name)
     {
         if (string.Equals(name, Store.ActiveToolProfileName, StringComparison.OrdinalIgnoreCase))
-            return FormatTool(Store, Store.IsMetric);
+            return FormatTool(Store, PreviewIsMetric);
         var temp = new ConfigurationStore();
         bool ok = ToolProfileJsonService.Load(ToolsDirectory, name, temp, out _, out _, quarantineOnFailure: false)
                || ProfileJsonServiceV1.Load(ProfilesDirectory, name, temp);
-        return ok ? FormatTool(temp, Store.IsMetric) : $"Tool profile '{name}'\n(file not found / unreadable)";
+        return ok ? FormatTool(temp, PreviewIsMetric) : $"Tool profile '{name}'\n(file not found / unreadable)";
     }
+
+    // Units for the profile previews follow the authoritative user setting
+    // (AppSettings.IsMetric — the documented source of truth), NOT the device
+    // store's flag. Store.IsMetric only re-syncs on a profile load/save, so on a
+    // bare metric/imperial toggle it lags and the picker showed metres in imperial.
+    private bool PreviewIsMetric => settingsService.Settings.IsMetric;
 
     /// <summary>
     /// A stored length (metres) rendered for display: "2.50 m" or "8.20 ft". These


### PR DESCRIPTION
## What changed

The **Vehicle & Tool picker previews** (`ConfigurationService.GetVehicleProfilePreview` / `GetToolProfilePreview`) formatted lengths using `Store.IsMetric` (the device `ConfigurationStore` flag). They now read the authoritative user setting `AppSettings.IsMetric` (`settingsService.Settings.IsMetric`), via a small `PreviewIsMetric` helper.

## Why

`Store.IsMetric` only re-syncs to `AppSettings.IsMetric` on a **profile load/save** (see `ReconcileIsMetricAfterProfileLoad`, whose own summary states *"AppSettings is authoritative"*). On a bare metric/imperial toggle in Settings, the status frame flips to imperial but the picker previews keep rendering metric -- so you see `Wheelbase: 2.50 m` / `Width: 6.00 m` while the rest of the UI is in feet.

Every other measurement in the web UI is converted client-side off the status `isMetric` flag, so these host-rendered preview strings were the one place a units toggle didn't reach.

This looks like the same class of issue as the recent *"Fix the three host-side unit strings the JS conversion couldn't reach"* change on `develop` -- the Vehicle & Tool profile previews are another host-rendered unit string that was missed.

## Repro (headless v26.6.74)

Set Settings -> Imperial, then open Field Operations -> Vehicle & Tool (or Fields and Jobs). The status frame reports `isMetric=false`, but the vehicle/tool previews still show `... m`. With this change they render `... ft`.

## Testing

- `dotnet build Shared/AgOpenWeb.Services` (`-p:DesktopOnly=true`, .NET 10.0.401): **0 errors**.
- Live headless instance: confirmed the previews were the only display still metric under imperial, and that `settingsService.Settings.IsMetric` matches what the status frame reports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Dre1bS3Fvi3VmUJGvnUDj
