### PR TITLE
Fix: route data paths through AppDataRoot + honor imperial in remaining host strings

### DIFF
--- a/Shared/AgOpenWeb.RemoteWiring/AgShareRemote.cs
+++ b/Shared/AgOpenWeb.RemoteWiring/AgShareRemote.cs
@@ -40,7 +40,7 @@ internal static class AgShareRemote
         var key = c.AgShareApiKey ?? "";
         var root = settings.Settings.FieldsDirectory;
         if (string.IsNullOrWhiteSpace(root))
-            root = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "AgOpenWeb", "Fields");
+            root = Path.Combine(AppDataRoot.Documents, "Fields");
         switch (cmd)
         {
             case "agshare.test": _ = TestAsync(state, url, key); return;

--- a/Shared/AgOpenWeb.RemoteWiring/RemoteServerWiring.Helpers.cs
+++ b/Shared/AgOpenWeb.RemoteWiring/RemoteServerWiring.Helpers.cs
@@ -524,8 +524,7 @@ public static partial class RemoteServerWiring
                 try
                 {
                     var dir = System.IO.Path.Combine(
-                        System.Environment.GetFolderPath(System.Environment.SpecialFolder.MyDocuments),
-                        "AgOpenWeb", "BugReports");
+                        AgOpenWeb.Services.AppDataRoot.Documents, "BugReports");
                     var slug = string.IsNullOrWhiteSpace(title) ? "untitled"
                         : new string(title.Trim().ToLowerInvariant().Select(ch => char.IsLetterOrDigit(ch) ? ch : '-').ToArray());
                     if (slug.Length > 60) slug = slug.Substring(0, 60);

--- a/Shared/AgOpenWeb.Services/BatteryForceMarker.cs
+++ b/Shared/AgOpenWeb.Services/BatteryForceMarker.cs
@@ -43,13 +43,7 @@ public static class BatteryForceMarker
     {
         try
         {
-            var documents = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
-            if (string.IsNullOrEmpty(documents))
-            {
-                documents = Environment.GetFolderPath(Environment.SpecialFolder.Personal);
-            }
-            if (string.IsNullOrEmpty(documents)) return false;
-            return File.Exists(Path.Combine(documents, "AgOpenWeb", MarkerFileName));
+            return File.Exists(Path.Combine(AppDataRoot.Documents, MarkerFileName));
         }
         catch
         {

--- a/Shared/AgOpenWeb.Services/DevOverlayMarker.cs
+++ b/Shared/AgOpenWeb.Services/DevOverlayMarker.cs
@@ -44,16 +44,7 @@ public static class DevOverlayMarker
     {
         try
         {
-            var documents = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
-            if (string.IsNullOrEmpty(documents))
-            {
-                documents = Environment.GetFolderPath(Environment.SpecialFolder.Personal);
-            }
-            if (string.IsNullOrEmpty(documents))
-            {
-                return false;
-            }
-            var path = Path.Combine(documents, "AgOpenWeb", MarkerFileName);
+            var path = Path.Combine(AppDataRoot.Documents, MarkerFileName);
             return File.Exists(path);
         }
         catch

--- a/Shared/AgOpenWeb.ViewModels/MainViewModel.Commands.Fields.cs
+++ b/Shared/AgOpenWeb.ViewModels/MainViewModel.Commands.Fields.cs
@@ -107,8 +107,7 @@ public partial class MainViewModel
             if (string.IsNullOrWhiteSpace(fieldsDir))
             {
                 fieldsDir = Path.Combine(
-                    Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments),
-                    "AgOpenWeb", "Fields");
+                    AppDataRoot.Documents, "Fields");
             }
             _fieldSelectionDirectory = fieldsDir;
             PopulateAvailableFields(fieldsDir);
@@ -218,8 +217,7 @@ public partial class MainViewModel
             if (string.IsNullOrWhiteSpace(fieldsDir))
             {
                 fieldsDir = Path.Combine(
-                    Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments),
-                    "AgOpenWeb", "Fields");
+                    AppDataRoot.Documents, "Fields");
             }
 
             var fieldPath = Path.Combine(fieldsDir, NewFieldName);
@@ -299,8 +297,7 @@ public partial class MainViewModel
             if (string.IsNullOrWhiteSpace(fieldsDir))
             {
                 fieldsDir = Path.Combine(
-                    Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments),
-                    "AgOpenWeb", "Fields");
+                    AppDataRoot.Documents, "Fields");
             }
             _fieldSelectionDirectory = fieldsDir;
             PopulateAvailableFields(fieldsDir);
@@ -346,8 +343,7 @@ public partial class MainViewModel
             if (string.IsNullOrWhiteSpace(fieldsDir))
             {
                 fieldsDir = Path.Combine(
-                    Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments),
-                    "AgOpenWeb", "Fields");
+                    AppDataRoot.Documents, "Fields");
             }
 
             var sourcePath = Path.Combine(fieldsDir, FromExistingSelectedField.Name);
@@ -531,8 +527,7 @@ public partial class MainViewModel
             if (string.IsNullOrWhiteSpace(fieldsDir))
             {
                 fieldsDir = Path.Combine(
-                    Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments),
-                    "AgOpenWeb", "Fields");
+                    AppDataRoot.Documents, "Fields");
             }
 
             var newFieldPath = Path.Combine(fieldsDir, newFieldName);
@@ -671,8 +666,7 @@ public partial class MainViewModel
             if (string.IsNullOrWhiteSpace(fieldsDir))
             {
                 fieldsDir = Path.Combine(
-                    Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments),
-                    "AgOpenWeb", "Fields");
+                    AppDataRoot.Documents, "Fields");
             }
 
             var newFieldPath = Path.Combine(fieldsDir, newFieldName);
@@ -927,8 +921,7 @@ public partial class MainViewModel
             if (string.IsNullOrEmpty(fieldsDir))
             {
                 fieldsDir = Path.Combine(
-                    Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments),
-                    "AgOpenWeb", "Fields");
+                    AppDataRoot.Documents, "Fields");
             }
 
             var fieldPath = Path.Combine(fieldsDir, lastField);
@@ -998,7 +991,7 @@ public partial class MainViewModel
     {
         var dir = _settingsService.Settings.FieldsDirectory;
         return string.IsNullOrWhiteSpace(dir)
-            ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "AgOpenWeb", "Fields")
+            ? Path.Combine(AppDataRoot.Documents, "Fields")
             : dir;
     }
 

--- a/Shared/AgOpenWeb.ViewModels/MainViewModel.Commands.Settings.cs
+++ b/Shared/AgOpenWeb.ViewModels/MainViewModel.Commands.Settings.cs
@@ -31,6 +31,8 @@ using CommunityToolkit.Mvvm.Input;
 
 using CommunityToolkit.Mvvm.ComponentModel;
 
+using AgOpenWeb.Services;
+
 namespace AgOpenWeb.ViewModels;
 
 public partial class MainViewModel
@@ -265,8 +267,7 @@ public partial class MainViewModel
                 try
                 {
                     var bugReportsDir = Path.Combine(
-                        Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments),
-                        "AgOpenWeb", "BugReports");
+                        AppDataRoot.Documents, "BugReports");
 
                     var savedPath = Services.DebugDumpService.FinalizeBugReport(
                         sourceZipPath: _bugReportTempZipPath,
@@ -307,8 +308,7 @@ public partial class MainViewModel
                 await System.Threading.Tasks.Task.Delay(50);
 
                 var bugReportsDir = Path.Combine(
-                    Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments),
-                    "AgOpenWeb", "BugReports");
+                    AppDataRoot.Documents, "BugReports");
 
                 // Build filename from title: sanitize, replace spaces with hyphens
                 var titleSlug = string.IsNullOrWhiteSpace(BugReportTitle)
@@ -631,7 +631,9 @@ public partial class MainViewModel
         global.Items.Add(new SettingsValueItem("Active Profile", store.ActiveVehicleProfileName));
         global.Items.Add(new SettingsValueItem("Is Metric", store.IsMetric.ToString()));
         global.Items.Add(new SettingsValueItem("Num Sections", store.NumSections.ToString()));
-        global.Items.Add(new SettingsValueItem("Actual Tool Width", $"{store.ActualToolWidth:F2} m"));
+        global.Items.Add(new SettingsValueItem("Actual Tool Width",
+            store.IsMetric ? $"{store.ActualToolWidth:F2} m"
+                           : $"{AgOpenWeb.Models.Base.UnitConversion.MetersToFeet(store.ActualToolWidth):F2} ft"));
         SettingsTree.Add(global);
     }
 

--- a/Shared/AgOpenWeb.ViewModels/MainViewModel.Headland.cs
+++ b/Shared/AgOpenWeb.ViewModels/MainViewModel.Headland.cs
@@ -9,6 +9,8 @@ using System.Linq;
 using AgOpenWeb.Models.Base;
 using Microsoft.Extensions.Logging;
 
+using AgOpenWeb.Services;
+
 namespace AgOpenWeb.ViewModels;
 
 /// <summary>
@@ -901,7 +903,7 @@ public partial class MainViewModel
         {
             var fieldsDir = _settingsService.Settings.FieldsDirectory;
             if (string.IsNullOrEmpty(fieldsDir))
-                fieldsDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "AgOpenWeb", "Fields");
+                fieldsDir = Path.Combine(AppDataRoot.Documents, "Fields");
             var fieldPath = Path.Combine(fieldsDir, CurrentFieldName);
             Services.Headland.HeadlandSegmentFileService.Save(fieldPath, HeadlandSegments);
         }

--- a/Shared/AgOpenWeb.ViewModels/MainViewModel.cs
+++ b/Shared/AgOpenWeb.ViewModels/MainViewModel.cs
@@ -4001,9 +4001,15 @@ public partial class MainViewModel : ObservableObject
     public int TramStartPass => ConfigStore.Tram.StartPass;
     public double TramWidth => ConfigStore.Tram.TramWidth;
     public System.Collections.ObjectModel.ObservableCollection<Models.Tram.TramSystem> TramSystems => ConfigStore.Tram.Systems;
-    public string TramToolWidthDisplay => $"{ConfigStore.ActualToolWidth:F2} m";
-    public string TramWidthDisplay => $"{ConfigStore.Tram.TramWidth:F2} m";
-    public string TramTrackWidthDisplay => $"{ConfigStore.Vehicle.TrackWidth:F2} m";
+    public string TramToolWidthDisplay => FormatLengthMeters(ConfigStore.ActualToolWidth);
+    public string TramWidthDisplay => FormatLengthMeters(ConfigStore.Tram.TramWidth);
+    public string TramTrackWidthDisplay => FormatLengthMeters(ConfigStore.Vehicle.TrackWidth);
+    // A host-rendered length string, honoring the authoritative unit choice
+    // (AppSettings.IsMetric — same source as the profile previews), not a hardcoded metre.
+    private string FormatLengthMeters(double meters) =>
+        _settingsService.Settings.IsMetric
+            ? $"{meters:F2} m"
+            : $"{UnitConversion.MetersToFeet(meters):F2} ft";
     public string TramLineCountDisplay => $"{_tramLineService.ParallelTramLines.Count}";
     public ICommand? IncreaseTramStartPassCommand { get; private set; }
     public ICommand? DecreaseTramStartPassCommand { get; private set; }
@@ -4849,8 +4855,7 @@ public partial class MainViewModel : ObservableObject
         if (string.IsNullOrEmpty(fieldsDir))
         {
             fieldsDir = Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments),
-                "AgOpenWeb", "Fields");
+                AppDataRoot.Documents, "Fields");
         }
 
         var fieldPath = Path.Combine(fieldsDir, CurrentFieldName);
@@ -4921,8 +4926,7 @@ public partial class MainViewModel : ObservableObject
         if (string.IsNullOrEmpty(fieldsDir))
         {
             fieldsDir = Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments),
-                "AgOpenWeb", "Fields");
+                AppDataRoot.Documents, "Fields");
         }
 
         var fieldPath = Path.Combine(fieldsDir, CurrentFieldName);


### PR DESCRIPTION
## Summary

Two related consistency fixes for the **headless/appliance** path and **imperial units**, in the same vein as #80 (KML/ISO import folder) and #81 (profile previews). Independent of those (different files/lines — no overlap).

## Part 1 — data paths honor the `AGOPENWEB_DATA` root

Several spots resolved data directories from `Environment.SpecialFolder.MyDocuments` instead of `AppDataRoot.Documents` (the single resolver that honors the `AGOPENWEB_DATA` env var the appliance sets). On a headless install `MyDocuments` (`~/Documents`) diverges from the data root, so these land outside where `Fields/`, `Tools/`, etc. live.

- **`app.bugReport` (remote/headless) dumps** — this was the *primary* path, not a fallback: on the appliance, "Bug Report Dump" wrote to `~/Documents/AgOpenWeb/BugReports` instead of `<AGOPENWEB_DATA>/AgOpenWeb/BugReports`. **Verified live.** (`RemoteServerWiring.Helpers.cs`)
- Native bug-report dumps (`MainViewModel.Commands.Settings.cs`), AgShare fields root (`AgShareRemote.cs`), the `FieldsDirectory` fallbacks (`MainViewModel.Commands.Fields.cs`, `MainViewModel.Headland.cs`, `MainViewModel.cs`), and the dev/debug markers (`DevOverlayMarker` / `BatteryForceMarker`) now all use `AppDataRoot.Documents`. Most were fallbacks (only hit when the setting is empty), but they should agree with the data root.
- Left as-is: `DiagFlags` (Models layer can't reference `AppDataRoot`, which lives in Services).

## Part 2 — imperial in the remaining host-rendered unit strings

A couple of host-side display strings still hardcoded metres regardless of the unit setting (same family as #81, which fixed the profile previews):

- `MainViewModel.TramToolWidthDisplay` / `TramWidthDisplay` / `TramTrackWidthDisplay` -- now honor `AppSettings.IsMetric` (m / ft).
- The "Actual Tool Width" row in the View-All-Settings tree -- now branches on `IsMetric`.

## Testing

- `dotnet build` of `AgOpenWeb.RemoteWiring` + dependencies (`-p:DesktopOnly=true`, .NET 10.0.401): **0 errors**.
- The `app.bugReport` path fix verified on a live headless instance: the dump previously landed in `~/Documents/AgOpenWeb/BugReports`; with the fix it goes to the data root alongside `Fields/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Dre1bS3Fvi3VmUJGvnUDj
